### PR TITLE
Remove dropDown from dispute card and add evidences view

### DIFF
--- a/src/components/Dashboard/LatestActivity.js
+++ b/src/components/Dashboard/LatestActivity.js
@@ -13,7 +13,7 @@ function LatestActivity() {
     <Box heading="latest activity" padding={0}>
       <Stepper
         lineColor="rgba(255, 151, 128, 0.2)"
-        lineExtraHeight={5}
+        lineExtraHeight={10}
         lineTop={15}
         lineWidth={2}
         css={`

--- a/src/components/Disputes/DisputeCard.js
+++ b/src/components/Disputes/DisputeCard.js
@@ -1,16 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import {
-  Card,
-  GU,
-  ContextMenu,
-  ContextMenuItem,
-  IconInfo,
-  IdentityBadge,
-  textStyle,
-  useTheme,
-} from '@aragon/ui'
+import { Card, GU, IdentityBadge, textStyle, useTheme } from '@aragon/ui'
 
 import DisputeText from './DisputeText'
 import DisputeStatus from './DisputeStatus'
@@ -28,7 +19,7 @@ function DisputeCard({ dispute, selectDispute }) {
   } = dispute
 
   return (
-    <CardItem>
+    <CardItem onClick={() => selectDispute(dispute.id)}>
       <div
         css={`
           display: flex;
@@ -37,12 +28,6 @@ function DisputeCard({ dispute, selectDispute }) {
         `}
       >
         <DisputeStatus dispute={dispute} />
-        <ContextMenu>
-          <ContextMenuItem onClick={() => selectDispute(id)}>
-            <IconInfo />
-            View
-          </ContextMenuItem>
-        </ContextMenu>
       </div>
 
       <div

--- a/src/components/Disputes/DisputeDetail.js
+++ b/src/components/Disputes/DisputeDetail.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import { BackButton, Bar, Box, Split } from '@aragon/ui'
-import DisputeInfo from './DisputeInfo'
 
-import Timeline from './Timeline'
+import DisputeInfo from './DisputeInfo'
+import DisputeEvidences from './DisputeEvidences'
+import DisputeTimeline from './DisputeTimeline'
 
 function DisputeDetail({ dispute, onBack }) {
   return (
@@ -12,12 +13,19 @@ function DisputeDetail({ dispute, onBack }) {
       </Bar>
 
       <Split
-        primary={<DisputeInfo dispute={dispute} />}
+        primary={
+          <React.Fragment>
+            <DisputeInfo dispute={dispute} />
+            {dispute.evidences && (
+              <DisputeEvidences evidences={dispute.evidences} />
+            )}
+          </React.Fragment>
+        }
         secondary={
           <React.Fragment>
             <Box heading="Voting results">Results</Box>
             <Box heading="Dispute timeline" padding={0}>
-              <Timeline />
+              <DisputeTimeline />
             </Box>
           </React.Fragment>
         }

--- a/src/components/Disputes/DisputeEvidences.js
+++ b/src/components/Disputes/DisputeEvidences.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Accordion, GU, IconFolder, useTheme } from '@aragon/ui'
+
+function DisputeEvidences({ evidences }) {
+  const theme = useTheme()
+
+  return (
+    <React.Fragment>
+      {evidences.map((evidence, index) => (
+        <Accordion
+          key={index}
+          items={[
+            [
+              <div
+                css={`
+                  display: flex;
+                  align-items: center;
+                `}
+              >
+                <IconFolder
+                  css={`
+                    margin-right: ${1 * GU}px;
+                  `}
+                  color={theme.surfaceIcon}
+                />
+                <span>Evidence #{index + 1}</span>
+              </div>,
+              <div
+                css={`
+                  padding: ${3 * GU}px ${8 * GU}px;
+                `}
+              >
+                {evidence}
+              </div>,
+            ],
+          ]}
+        />
+      ))}
+    </React.Fragment>
+  )
+}
+
+export default DisputeEvidences

--- a/src/components/Disputes/DisputeInfo.js
+++ b/src/components/Disputes/DisputeInfo.js
@@ -37,7 +37,7 @@ const DisputeInfo = ({ dispute }) => {
         <div
           css={`
             display: flex;
-            margin-bottom: ${5 * GU}px;
+            margin-bottom: ${3 * GU}px;
             justify-content: space-between;
           `}
         >

--- a/src/components/Disputes/DisputeTimeline.js
+++ b/src/components/Disputes/DisputeTimeline.js
@@ -5,7 +5,7 @@ import { timeline } from '../../mock-data'
 import Stepper from '../Stepper'
 import Step from '../Step'
 
-function Timeline() {
+function DisputeTimeline() {
   const theme = useTheme()
   const current = 4
 
@@ -78,4 +78,4 @@ function Timeline() {
   )
 }
 
-export default Timeline
+export default DisputeTimeline

--- a/src/mock-data.js
+++ b/src/mock-data.js
@@ -67,6 +67,10 @@ export const disputes = [
     stakedAmount: 746,
     term: 1,
     termDate: '15/02/20',
+    evidences: [
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+    ],
   },
   {
     id: 1,
@@ -78,6 +82,10 @@ export const disputes = [
     stakedAmount: 865,
     term: 1,
     termDate: '15/02/20',
+    evidences: [
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+    ],
   },
   {
     id: 2,
@@ -89,6 +97,10 @@ export const disputes = [
     stakedAmount: 500,
     term: 1,
     termDate: '15/02/20',
+    evidences: [
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+    ],
   },
   {
     id: 3,
@@ -100,6 +112,10 @@ export const disputes = [
     stakedAmount: 1023,
     term: 1,
     termDate: '15/02/20',
+    evidences: [
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+    ],
   },
   {
     id: 4,
@@ -111,6 +127,10 @@ export const disputes = [
     stakedAmount: 985,
     term: 1,
     termDate: '15/02/20',
+    evidences: [
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+    ],
   },
   {
     id: 5,
@@ -122,6 +142,10 @@ export const disputes = [
     stakedAmount: 495,
     term: 1,
     termDate: '15/02/20',
+    evidences: [
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+    ],
   },
   {
     id: 6,
@@ -133,6 +157,10 @@ export const disputes = [
     stakedAmount: 385,
     term: 1,
     termDate: '15/02/20',
+    evidences: [
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+      "Agreement Text: An IPFS-hosted text document describing the agreement terms/n Alright, I'm ready. Marty, why are you so nervous? yes, Joey just loves being in his playpen. he cries whenever we take him out so we just leave him in there all the time. Well Marty, I hope you like meatloaf. Oh, then I wanna give her a call, I don't want her to worry about you. Excuse me.",
+    ],
   },
 ]
 


### PR DESCRIPTION
- Added evidences view 
- Also removed the dropdown actions form the dispute card and made the detail view accessible through onClick action.
- Decreased the margin between the `vote` button and the last row at `disputeInfo` component