### PR TITLE
react-app-rewired: use the .eslintrc file

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -2,4 +2,4 @@
 
 const { useBabelRc, override, useEslintRc } = require('customize-cra')
 
-module.exports = override(useBabelRc(), useEslintRc())
+module.exports = override(useBabelRc(), useEslintRc(__dirname + '/.eslintrc'))


### PR DESCRIPTION
For some reason it wasn’t used by react-app-rewired on my setup, setting it explicitly fixes that.