### PR TITLE
Graph reconnection attempts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,9 @@ subscriptionClient.onConnected(() => (connectionAttempts = 0))
 
 // Check for connection errors and if reaches max attempts send error log to Sentry
 subscriptionClient.onError(err => {
-  if (sentryEnabled && ++connectionAttempts) {
+  const maxReconnectionAttempts = subscriptionClient.reconnectionAttempts
+
+  if (sentryEnabled && maxReconnectionAttempts === ++connectionAttempts) {
     Sentry.captureException(
       `Connection error, could not connect to ${err.target.url}`
     )

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import { getNetworkName } from './lib/web3-utils'
 const [GRAPH_API_ENDPOINT_HTTP, GRAPH_API_ENDPOINT_WS] = endpoints()
 
 const subscriptionClient = new SubscriptionClient(GRAPH_API_ENDPOINT_WS, {
+  reconnect: true,
   reconnectionAttempts: 10,
 })
 
@@ -53,12 +54,11 @@ subscriptionClient.onError(err => {
   const maxReconnectionAttempts = subscriptionClient.reconnectionAttempts
 
   if (sentryEnabled && maxReconnectionAttempts === ++connectionAttempts) {
-    Sentry.captureException(
+    Sentry.captureMessage(
       `Connection error, could not connect to ${err.target.url}`
     )
   }
   console.log('Retrying connection...')
-  subscriptionClient.reconnect = true
 })
 
 ReactDOM.render(

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ import { getNetworkName } from './lib/web3-utils'
 const [GRAPH_API_ENDPOINT_HTTP, GRAPH_API_ENDPOINT_WS] = endpoints()
 
 const subscriptionClient = new SubscriptionClient(GRAPH_API_ENDPOINT_WS, {
-  reconnectionAttempts: 5,
+  reconnectionAttempts: 10,
 })
 
 const client = createClient({


### PR DESCRIPTION
closes #90 

Includes connection retry and in the case we reach the maximum number of connection attempts (set to 10) we send an error log to Sentry.