### PR TITLE
Check last round appealed to compute final outcome

### DIFF
--- a/src/components/Disputes/DisputeInfo.js
+++ b/src/components/Disputes/DisputeInfo.js
@@ -45,6 +45,8 @@ const DisputeInfo = React.memo(function({
   const isFinalRulingEnsured =
     phase === DisputePhase.ExecuteRuling || status === DipsuteStatus.Closed
 
+  const lastRound = dispute?.rounds[dispute.lastRoundId]
+
   return (
     <Box>
       <section
@@ -67,7 +69,8 @@ const DisputeInfo = React.memo(function({
                   value={
                     <DisputeOutcomeText
                       outcome={
-                        dispute.rounds[dispute.lastRoundId].vote.winningOutcome
+                        lastRound.appeal?.appealedRuling ||
+                        lastRound.vote?.winningOutcome
                       }
                       phase={dispute.phase}
                       disputeEnded={isFinalRulingEnsured}


### PR DESCRIPTION
It can happen that a dispute is appealed, but no one confirms the appeal. 

In these cases, the final ruling of the dispute is the ruling the appealer ruled for.