### PR TITLE
Timeline: Fix UI bug

### DIFF
--- a/src/components/Disputes/DisputeTimeline.js
+++ b/src/components/Disputes/DisputeTimeline.js
@@ -296,6 +296,11 @@ const StyledAccordion = styled.div`
     border-left: 0;
     border-right: 0;
   }
+
+  &::after {
+    height: 0px !important;
+    width: 0px !important;
+  }
 `
 
 export default DisputeTimeline


### PR DESCRIPTION
Noticed that when a new round is created, the `::after` content for the accordions is displayed and at the bottom of the `<Box />`

<img width="364" alt="Screen Shot 2020-02-10 at 2 38 15 AM" src="https://user-images.githubusercontent.com/22663232/74123935-2af0b700-4baf-11ea-8c97-6d24417638a8.png">

This PR hides the line for accordions