### PR TITLE
Add mainnet deployment configuration

### DIFF
--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install node
       uses: actions/setup-node@v1
       with:
-        node-version: 10
+        node-version: 12
     - name: npm install
       run: npm install
     - name: npm lint

--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -1,0 +1,24 @@
+name: Mainnet deployment
+
+on:
+  push:
+    branches:
+      -  development
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10
+    - name: npm install
+      run: npm install
+    - name: npm lint
+      run: npm run lint
+    - name: now
+      run: now -A now-mainnet.json --prod --token=${{ secrets.ZEIT_TOKEN }}
+    env:
+      CI: true

--- a/now-mainnet.json
+++ b/now-mainnet.json
@@ -1,0 +1,12 @@
+{
+  "version": 2,
+  "public": true,
+  "scope": "aragon",
+  "alias": "court.aragon.org",
+  "build": {
+    "env": {
+      "REACT_APP_CHAIN_ID": "1",
+      "REACT_APP_SENTRY_DSN": "@court-dashboard-sentry-dsn"
+    }
+  }
+}

--- a/now.json
+++ b/now.json
@@ -1,4 +1,8 @@
 {
+  "version": 2,
+  "public": true,
+  "scope": "aragon",
+  "alias": "court-rinkeby.aragon.org",
   "build": {
     "env": {
       "REACT_APP_SENTRY_DSN": "@court-dashboard-sentry-dsn"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "build:mainnet": "REACT_APP_CHAIN_ID=1 npm run build",
     "build:ropsten": "REACT_APP_CHAIN_ID=3 npm run build",
     "build:rinkeby": "REACT_APP_CHAIN_ID=4 npm run build",
+    "lint": "eslint ./src",
     "test": "react-app-rewired test",
     "eject": "react-scripts eject",
     "optimize": "npm run optimize:svg",


### PR DESCRIPTION
This adds a Github Action to "manually" deploy a mainnet build via Now on merges to `development`.

We will continue using the Now Github integration to deploy Rinkeby builds from PRs and merges to `development`.

DNS configuration being set up now.