### PR TITLE
Update max ANJ  amount to active from inactive balance

### DIFF
--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -122,7 +122,7 @@ function Dashboard() {
 
 function PanelComponent({ mode, actions, balances, ...props }) {
   const { activateANJ, deactivateANJ, withdrawANJ } = actions
-  const { walletBalance, activeBalance, inactiveBalance } = balances
+  const { walletBalance, activeBalance } = balances
 
   const unlockedActiveBalance = getTotalUnlockedActiveBalance(balances)
   const effectiveInactiveBalance = getTotalEffectiveInactiveBalance(balances)
@@ -148,7 +148,7 @@ function PanelComponent({ mode, actions, balances, ...props }) {
       return (
         <ActivateANJ
           activeBalance={activeBalance.amount}
-          inactiveBalance={inactiveBalance.amount}
+          inactiveBalance={effectiveInactiveBalance}
           walletBalance={walletBalance.amount}
           onActivateANJ={activateANJ}
           fromWallet={mode === REQUEST_MODE.STAKE_ACTIVATE}


### PR DESCRIPTION
Since now deactivation requests are processed before activating ANJ, we 
update the max amount allowed for activation from inactive wallet. 