### PR TITLE
Increase gas limit for ANJ activation

### DIFF
--- a/src/hooks/useCourtContracts.js
+++ b/src/hooks/useCourtContracts.js
@@ -23,6 +23,7 @@ import { retryMax } from '../utils/retry-max'
 
 const ACTIVATE_SELECTOR = getFunctionSignature('activate(uint256)')
 const GAS_LIMIT = 1200000
+const ANJ_ACTIVATE_GAS_LIMIT = 500000
 const ANJ_ACTIONS_GAS_LIMIT = 325000
 
 // ANJ contract
@@ -72,7 +73,7 @@ export function useANJActions() {
   const activateANJ = useCallback(
     amount => {
       return jurorRegistryContract.activate(amount, {
-        gasLimit: ANJ_ACTIONS_GAS_LIMIT,
+        gasLimit: ANJ_ACTIVATE_GAS_LIMIT,
       })
     },
     [jurorRegistryContract]


### PR DESCRIPTION
See https://etherscan.io/tx/0xab402538f9ec655947f405540bcabdbbd3fc004cadfd557872f3ee29484d747c.

The transaction takes 300k gas overall, but because of EIP-150's 63/64th gas rule, the inner call  to "draw" funds from the token into the juror does not receive enough gas to complete.

I've updated this to 500k gas in the meantime, as a safe limit (again, this is why web3 providers do gas estimations on their side 😄).