### PR TITLE
Timeline: Set icons width

### DIFF
--- a/src/components/Disputes/DisputeTimeline.js
+++ b/src/components/Disputes/DisputeTimeline.js
@@ -234,10 +234,9 @@ function PhaseIcon({ phase, active }) {
 
   return (
     <img
-      css={`
-        height: ${GU * 6}px;
-      `}
       src={active ? icon.active : icon.inactive}
+      width={6 * GU}
+      height={6 * GU}
       alt=""
     />
   )


### PR DESCRIPTION
Following @bpierre 's advice on setting the width on icons that have text close to them so it doesn't make a weird transition when loading images.