### PR TITLE
Timer: Use Date instead of dayjs

### DIFF
--- a/src/components/Disputes/DisputePhase.js
+++ b/src/components/Disputes/DisputePhase.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import { GU, textStyle, Timer, useTheme } from '@aragon/ui'
 
-import dayjs from '../../lib/dayjs'
 import { Phase, convertToString } from '../../types/dispute-status-types'
 
 function DisputePhase({ phase, nextTransition }) {
   const stringPhase = convertToString(phase)
+
   return (
     <div
       css={`
@@ -88,7 +88,7 @@ function DisplayTime({ phase, nextTransition }) {
         margin-bottom: ${2 * GU}px;
       `}
     >
-      <Timer end={dayjs(nextTransition)} />
+      <Timer end={new Date(nextTransition)} />
     </div>
   )
 }

--- a/src/components/Disputes/DisputeTimeline.js
+++ b/src/components/Disputes/DisputeTimeline.js
@@ -24,7 +24,6 @@ import {
   Phase as DisputePhase,
   getPhaseStringForStatus,
 } from '../../types/dispute-status-types'
-import dayjs from '../../lib/dayjs'
 import { dateFormat } from '../../utils/date-utils'
 import { getDisputeTimeLine } from '../../utils/dispute-utils'
 
@@ -252,7 +251,7 @@ function DisplayTime({ item }) {
     ) {
       return 'ANY TIME'
     }
-    return <Timer end={dayjs(endTime)} />
+    return <Timer end={new Date(endTime)} />
   }
   return <>{dateFormat(endTime, 'DD/MM/YY')}</>
 }


### PR DESCRIPTION
The `end` prop on `Timer` expects a `Date` instead of a `dayjs` object.