### PR TITLE
Dashboard: fix help text for locked active tokens

### DIFF
--- a/src/components/Dashboard/Balance.js
+++ b/src/components/Dashboard/Balance.js
@@ -9,7 +9,7 @@ import { useCourtConfig } from '../../providers/CourtConfig'
 import useBalanceToUsd from '../../hooks/useTokenBalanceToUsd'
 
 import { PCT_BASE } from '../../utils/dispute-utils'
-import { formatTokenAmount, formatUnits } from '../../lib/math-utils'
+import { bigNum, formatTokenAmount, formatUnits } from '../../lib/math-utils'
 import { movementDirection, convertToString } from '../../types/anj-types'
 
 import ANJIcon from '../../assets/IconANJ.svg'
@@ -306,12 +306,12 @@ function useHelpAttributes(distribution) {
 
     let text
     const { decimals, symbol } = anjToken
-    const penaltyPercentage = PCT_BASE.div(penaltyPct)
+    const penaltyPercentage = bigNum(penaltyPct).div(PCT_BASE.div(100))
     const minActiveBalanceFormatted = formatUnits(minActiveBalance, {
       digits: decimals,
     })
     const minLockedAmountFormatted = formatUnits(
-      minActiveBalance.div(penaltyPercentage),
+      minActiveBalance.mul(penaltyPct).div(PCT_BASE),
       { digits: decimals }
     )
 


### PR DESCRIPTION
Before:

<img width="418" alt="image" src="https://user-images.githubusercontent.com/447328/74591999-d2b41d80-4fd1-11ea-8f63-c0a25f9b6039.png">

After:

<img width="428" alt="image" src="https://user-images.githubusercontent.com/447328/74591973-a5676f80-4fd1-11ea-92d8-343403002aef.png">
