### PR TITLE
Appeal: amend info copy

### DIFF
--- a/src/components/Dashboard/Balance.js
+++ b/src/components/Dashboard/Balance.js
@@ -9,7 +9,7 @@ import { useCourtConfig } from '../../providers/CourtConfig'
 import useBalanceToUsd from '../../hooks/useTokenBalanceToUsd'
 
 import { PCT_BASE } from '../../utils/dispute-utils'
-import { formatTokenAmount, formatUnits } from '../../lib/math-utils'
+import { bigNum, formatTokenAmount, formatUnits } from '../../lib/math-utils'
 import { movementDirection, convertToString } from '../../types/anj-types'
 
 import ANJIcon from '../../assets/IconANJ.svg'
@@ -306,12 +306,12 @@ function useHelpAttributes(distribution) {
 
     let text
     const { decimals, symbol } = anjToken
-    const penaltyPercentage = PCT_BASE.div(penaltyPct)
+    const penaltyPercentage = bigNum(penaltyPct).div(PCT_BASE.div(100))
     const minActiveBalanceFormatted = formatUnits(minActiveBalance, {
       digits: decimals,
     })
     const minLockedAmountFormatted = formatUnits(
-      minActiveBalance.div(penaltyPercentage),
+      minActiveBalance.mul(penaltyPct).div(PCT_BASE),
       { digits: decimals }
     )
 

--- a/src/components/Disputes/actions/DisputeAppeal.js
+++ b/src/components/Disputes/actions/DisputeAppeal.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import { Button, Info, GU } from '@aragon/ui'
+import { Button, GU, Info, Link } from '@aragon/ui'
 import { useWallet } from '../../../providers/Wallet'
 
 function DisputeAppeal({ onRequestAppeal, confirm }) {
@@ -24,8 +24,22 @@ function DisputeAppeal({ onRequestAppeal, confirm }) {
       >
         {actionLabel}
       </Button>
-      <Info mode="description">
-        Anyone holding the required appeal deposit can trigger this action.
+      <Info>
+        <strong>Anyone</strong> can{' '}
+        <strong>
+          lock DAI as collateral to{' '}
+          {confirm ? 'confirm an appeal' : 'propose an appeal'}{' '}
+        </strong>
+        , if they don’t agree with the current outcome. When the final ruling is
+        confirmed, the user who {confirm ? 'confirmed the appeal' : 'appealed'}{' '}
+        gets rewarded if the ruling has switched in their favor. If not, their
+        entire collateral could be re-distributed to the winning party.{' '}
+        {confirm
+          ? 'If an appeal is confirmed, a new adjudication round is initiated and a new jury is drafted.'
+          : ''}
+        <Link href="https://help.aragon.org/article/43-dispute-lifecycle#appeal">
+          Learn more
+        </Link>
       </Info>
     </div>
   )

--- a/src/components/Disputes/actions/DisputeAppeal.js
+++ b/src/components/Disputes/actions/DisputeAppeal.js
@@ -28,17 +28,19 @@ function DisputeAppeal({ onRequestAppeal, confirm }) {
         <strong>Anyone</strong> can{' '}
         <strong>
           lock DAI as collateral to{' '}
-          {confirm ? 'confirm an appeal' : 'propose an appeal'}{' '}
+          {confirm ? 'confirm an appeal' : 'initiate an appeal'}{' '}
         </strong>
-        , if they don’t agree with the current outcome. When the final ruling is
-        confirmed, the user who {confirm ? 'confirmed the appeal' : 'appealed'}{' '}
-        gets rewarded if the ruling has switched in their favor. If not, their
-        entire collateral could be re-distributed to the winning party.{' '}
+        , if they believe the{' '}
+        {confirm ? 'ruling appealed for' : 'current outcome'} is incorrect. When
+        the final ruling is confirmed, the user who{' '}
+        {confirm ? 'confirmed the appeal' : 'appealed'} gets rewarded if the
+        ruling has switched in their favor. If not, their entire collateral
+        could be re-distributed to the winning party.{' '}
         {confirm
-          ? 'If an appeal is confirmed, a new adjudication round is initiated and a new jury is drafted.'
-          : ''}
+          ? 'When an appeal is confirmed, a new adjudication round is initiated and a new jury is drafted. '
+          : 'If an appeal is confirmed, a new adjudication round is initiated and a new jury is drafted. '}
         <Link href="https://help.aragon.org/article/43-dispute-lifecycle#appeal">
-          Learn more
+          Learn more.
         </Link>
       </Info>
     </div>

--- a/src/components/Disputes/actions/DisputeAppeal.js
+++ b/src/components/Disputes/actions/DisputeAppeal.js
@@ -30,15 +30,14 @@ function DisputeAppeal({ onRequestAppeal, confirm }) {
           lock DAI as collateral to{' '}
           {confirm ? 'confirm an appeal' : 'initiate an appeal'}{' '}
         </strong>
-        , if they believe the{' '}
+        if they believe the{' '}
         {confirm ? 'ruling appealed for' : 'current outcome'} is incorrect. When
         the final ruling is confirmed, the user who{' '}
         {confirm ? 'confirmed the appeal' : 'appealed'} gets rewarded if the
         ruling has switched in their favor. If not, their entire collateral
-        could be re-distributed to the winning party.{' '}
-        {confirm
-          ? 'When an appeal is confirmed, a new adjudication round is initiated and a new jury is drafted. '
-          : 'If an appeal is confirmed, a new adjudication round is initiated and a new jury is drafted. '}
+        could be re-distributed to the winning party. {confirm ? 'When' : 'If'}{' '}
+        an appeal is confirmed, a new adjudication round is initiated and a new
+        jury is drafted.{' '}
         <Link href="https://help.aragon.org/article/43-dispute-lifecycle#appeal">
           Learn more.
         </Link>

--- a/src/components/Disputes/actions/DisputeAppeal.js
+++ b/src/components/Disputes/actions/DisputeAppeal.js
@@ -39,8 +39,9 @@ function DisputeAppeal({ onRequestAppeal, confirm }) {
         an appeal is confirmed, a new adjudication round is initiated and a new
         jury is drafted.{' '}
         <Link href="https://help.aragon.org/article/43-dispute-lifecycle#appeal">
-          Learn more.
+          Learn more
         </Link>
+        .
       </Info>
     </div>
   )

--- a/src/components/Disputes/actions/DisputeAppeal.js
+++ b/src/components/Disputes/actions/DisputeAppeal.js
@@ -1,9 +1,8 @@
 import React, { useCallback } from 'react'
-import { Button, Info, GU, useTheme } from '@aragon/ui'
+import { Button, Info, GU } from '@aragon/ui'
 import { useWallet } from '../../../providers/Wallet'
 
 function DisputeAppeal({ onRequestAppeal, confirm }) {
-  const theme = useTheme()
   const wallet = useWallet()
 
   const actionLabel = confirm ? 'Confirm appeal' : 'Appeal Ruling'
@@ -26,14 +25,7 @@ function DisputeAppeal({ onRequestAppeal, confirm }) {
         {actionLabel}
       </Button>
       <Info mode="description">
-        Anyone can trigger this action, and whoever does will get some{' '}
-        <span
-          css={`
-            color: ${theme.help};
-          `}
-        >
-          rewards.
-        </span>
+        Anyone holding the required appeal deposit can trigger this action.
       </Info>
     </div>
   )

--- a/src/components/Disputes/actions/DisputeDraft.js
+++ b/src/components/Disputes/actions/DisputeDraft.js
@@ -30,8 +30,8 @@ function DisputeDraft({ disputeId, onDraft }) {
         </Button>
       </div>
       <Info>
-        The evidence submission period is closed. Anyone can now trigger the
-        drafting of jury and earn some rewards.
+        The evidence submission period is closed. <strong>Anyone</strong> can
+        now trigger the drafting of jury and earn some rewards.
       </Info>
     </form>
   )

--- a/src/components/Disputes/actions/DisputeExecuteRuling.js
+++ b/src/components/Disputes/actions/DisputeExecuteRuling.js
@@ -1,9 +1,8 @@
 import React from 'react'
-import { Button, GU, Info, useTheme } from '@aragon/ui'
+import { Button, GU, Info } from '@aragon/ui'
 import { useWallet } from '../../../providers/Wallet'
 
 function DisputeExecuteRuling({ disputeId, onExecuteRuling }) {
-  const theme = useTheme()
   const wallet = useWallet()
 
   const handleSubmit = async event => {
@@ -31,14 +30,7 @@ function DisputeExecuteRuling({ disputeId, onExecuteRuling }) {
         </Button>
       </div>
       <Info>
-        Anyone can now trigger this action and earn some{' '}
-        <span
-          css={`
-            color: ${theme.help};
-          `}
-        >
-          rewards.
-        </span>
+        <strong>Anyone</strong> can now trigger this action.
       </Info>
     </form>
   )

--- a/src/components/Disputes/actions/DisputeReveal.js
+++ b/src/components/Disputes/actions/DisputeReveal.js
@@ -14,7 +14,7 @@ function DisputeReveal({ onRequestReveal }) {
       >
         Reveal your vote
       </Button>
-      <Info mode="description">
+      <Info>
         You will be asked a one-time-use code before you can reveal your vote.
       </Info>
     </div>

--- a/src/components/Disputes/panels/AppealPanel.js
+++ b/src/components/Disputes/panels/AppealPanel.js
@@ -194,7 +194,7 @@ const AppealPanel = React.memo(function AppealPanel({
       )}
       <Info>
         Please note that if the final ruling outcome is different from your
-        selected appeal, the entire amount of your collateral will be slashed.{' '}
+        selected appeal, the entire amount of your collateral could be slashed.{' '}
         <Link href="#">Learn more</Link> {/* TODO: add ref */}
       </Info>
     </form>

--- a/src/components/Disputes/panels/AppealPanel.js
+++ b/src/components/Disputes/panels/AppealPanel.js
@@ -195,7 +195,9 @@ const AppealPanel = React.memo(function AppealPanel({
       <Info>
         Please note that if the final ruling outcome is different from your
         selected appeal, the entire amount of your collateral could be slashed.{' '}
-        <Link href="#">Learn more</Link> {/* TODO: add ref */}
+        <Link href="https://help.aragon.org/article/43-dispute-lifecycle#appeal">
+          Learn more
+        </Link>
       </Info>
     </form>
   )

--- a/src/components/Disputes/panels/AppealPanel.js
+++ b/src/components/Disputes/panels/AppealPanel.js
@@ -196,7 +196,7 @@ const AppealPanel = React.memo(function AppealPanel({
         Please note that if the final ruling outcome is different from your
         selected appeal, the entire amount of your collateral could be slashed.{' '}
         <Link href="https://help.aragon.org/article/43-dispute-lifecycle#appeal">
-          Learn more
+          Learn more.
         </Link>
       </Info>
     </form>

--- a/src/components/Disputes/panels/AppealPanel.js
+++ b/src/components/Disputes/panels/AppealPanel.js
@@ -196,8 +196,9 @@ const AppealPanel = React.memo(function AppealPanel({
         Please note that if the final ruling outcome is different from your
         selected appeal, the entire amount of your collateral could be slashed.{' '}
         <Link href="https://help.aragon.org/article/43-dispute-lifecycle#appeal">
-          Learn more.
+          Learn more
         </Link>
+        .
       </Info>
     </form>
   )

--- a/src/components/Disputes/panels/CommitPanel.js
+++ b/src/components/Disputes/panels/CommitPanel.js
@@ -258,8 +258,8 @@ const RevealService = React.memo(function RevealService({
       >
         By enabling this feature you trust Aragon One to reveal your vote on
         your behalf in this and following disputes. You can always turn off this
-        service later if you choose. <Link>Learn more</Link>
-        {/* TODO: Add ref */}
+        service later if you choose.
+        {/* TODO: Add ref:  <Link>Learn more</Link>. */}
       </div>
     </React.Fragment>
   )

--- a/src/components/Disputes/panels/CommitPanel.js
+++ b/src/components/Disputes/panels/CommitPanel.js
@@ -5,7 +5,6 @@ import {
   IconCopy,
   IconDownload,
   Info,
-  Link,
   Switch,
   Tag,
   TextInput,


### PR DESCRIPTION
Noticed that some info sections where not entirely accurate. 

1. Execute ruling info section: Whoever executes the dispute ruling will not get rewards.

Users can earn rewards from executing actions when: 
- Drafting
- Settling penalties

2. When appealing, if the final ruling of a dispute is different from the ruling appealed for, the appealer will lose the entire deposit only if the opposed ruling is the same as  the final ruling. Otherwise, both parties will get their deposits back  `- (round fees )/ 2`.

Fixes #189.