### PR TITLE
Remove Fortmatic verification meta

### DIFF
--- a/now-mainnet.json
+++ b/now-mainnet.json
@@ -8,8 +8,7 @@
       "REACT_APP_CHAIN_ID": "1",
       "REACT_APP_SENTRY_DSN": "@court-dashboard-sentry-dsn",
       "REACT_APP_FORTMATIC_API_KEY": "@court-dashboard-fortmatic-api-key",
-      "REACT_APP_PORTIS_DAPP_ID": "@court-dashboard-portis-dapp-id",
-      "FORTMATIC_SITE_VERIFICATION": "@court-dashboard-fortmatic-site-verification"
+      "REACT_APP_PORTIS_DAPP_ID": "@court-dashboard-portis-dapp-id"
     }
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Aragon Court Dashboard" />
-    <meta name="head-extra" value="" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/icon.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -35,10 +35,3 @@ npm run sync-assets
 echo "Building app…"
 echo ""
 REACT_APP_ENABLE_SENTRY=$enable_sentry REACT_APP_BUILD=$build npx react-app-rewired build
-
-echo "Add post-build HTML tags"
-if [ -n "$FORTMATIC_SITE_VERIFICATION" ]; then
-  sed "s/<meta name=\"head\-extra\" value=\"\"\/>/<meta name=\"fortmatic-site-verification\" content=\"${FORTMATIC_SITE_VERIFICATION}\"\/>/" -i ./build/index.html
-else
-  sed "s/<meta name=\"head\-extra\" value=\"\"\/>//" -i ./build/index.html
-fi


### PR DESCRIPTION
Note: we should also remove the `court-dashboard-fortmatic-site-verification` secret on Now.