### PR TITLE
now: fix custom mainnet deployment action

### DIFF
--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -19,6 +19,13 @@ jobs:
     - name: npm lint
       run: npm run lint
     - name: now
-      run: now -A now-mainnet.json --prod --token=${{ secrets.ZEIT_TOKEN }} --build-env NOW_GITHUB_COMMIT_REF="development" --build-env NOW_GITHUB_COMMIT_SHA="$(git log --pretty=format:'%h' -n 1)"
+      run: >
+        now
+        -A now-mainnet.json
+        --confirm
+        --prod
+        --token=${{ secrets.ZEIT_TOKEN }}
+        --build-env NOW_GITHUB_COMMIT_REF="development"
+        --build-env NOW_GITHUB_COMMIT_SHA="$(git log --pretty=format:'%h' -n 1)"
     env:
       CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -5,13 +5,15 @@
 /.pnp
 .pnp.js
 
-/public/aragon-ui
-
 # testing
 /coverage
 
 # production
 /build
+/public/aragon-ui
+
+# zeit now configuration
+.now
 
 # misc
 .DS_Store
@@ -24,7 +26,3 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 package-lock.json
-
-aragon-ui
-
-.now


### PR DESCRIPTION
Now CLI v17 now asks for confirmation the first time a user tries to deploy; using `--confirm` confirms this check automatically on a CI environment.