### PR TITLE
Dispute timeline: Amend outcome texts

### DIFF
--- a/src/utils/crvoting-utils.js
+++ b/src/utils/crvoting-utils.js
@@ -40,8 +40,8 @@ export function appealOptionToString(outcome) {
 const outcomeStringMapping = {
   [OUTCOMES.Leaked]: 'Invalid ruling',
   [OUTCOMES.Refused]: 'Refused to vote',
-  [OUTCOMES.Against]: 'Voted against the plaintiff',
-  [OUTCOMES.InFavor]: 'Voted in favor of the plaintiff',
+  [OUTCOMES.Against]: 'Against plaintiff',
+  [OUTCOMES.InFavor]: 'In favor of plaintiff',
 }
 
 export function juryOutcomeToString(outcome) {


### PR DESCRIPTION
The outcome texts were too long for the timeline and were wrapped in the next line.

Followed [this figma file](https://www.figma.com/file/IdVA6iMn0cWLV5imylwEUP/%E2%9C%85-MASTER-Court-Dashboard?node-id=3783%3A0) to update them.