### PR TITLE
Use cryptocompare api for non ANJ tokens

### DIFF
--- a/src/components/Dashboard/Balance.js
+++ b/src/components/Dashboard/Balance.js
@@ -6,7 +6,7 @@ import Loading from './Loading'
 import ANJLockedDistribution from './ANJLockedDistribution'
 
 import { useCourtConfig } from '../../providers/CourtConfig'
-import useANJBalanceToUsd from '../../hooks/useANJBalanceToUsd'
+import { useANJBalanceToUsd } from '../../hooks/useTokenBalanceToUsd'
 
 import { PCT_BASE } from '../../utils/dispute-utils'
 import { bigNum, formatTokenAmount, formatUnits } from '../../lib/math-utils'

--- a/src/hooks/useTokenBalanceToUsd.js
+++ b/src/hooks/useTokenBalanceToUsd.js
@@ -3,12 +3,13 @@ import { getMarketDetails, getTokenReserves } from '@uniswap/sdk'
 import { useCourtConfig } from '../providers/CourtConfig'
 
 import env from '../environment'
-import { getDaiAddress } from '../utils/known-tokens'
+import { getTokenAddress } from '../utils/known-tokens'
 import { formatUnits, bigNum } from '../lib/math-utils'
 import { addressesEqual, ETH_FAKE_ADDRESS } from '../lib/web3-utils'
 
 const UNISWAP_PRECISION = 18
 const UNISWAP_MARKET_RETRY_EVERY = 1000
+const API_BASE = 'https://min-api.cryptocompare.com/data'
 
 async function getANJMarketDetails(tokenAddress, anjTokenAddress) {
   const [tokenData, anjData] = await Promise.all(
@@ -30,11 +31,17 @@ async function getANJMarketDetails(tokenAddress, anjTokenAddress) {
   return getMarketDetails(tokenData, anjData)
 }
 
-export default function useANJBalanceToUsd(amount) {
+/**
+ * @dev ANJ can only be bought in Uniswap for now so we'll get the ANJ <> DAI market details
+ * Convert ANJ amount into USD price
+ * @param {BigNum} amount The amount to convert to USD
+ * @returns {String} The amount value in USD
+ */
+export function useANJBalanceToUsd(amount) {
   const { anjToken } = useCourtConfig()
 
   // We'll use the ANJ <> DAI market details to get the spot price
-  const daiAddress = getDaiAddress()
+  const daiAddress = getTokenAddress('DAI')
 
   const [convertedAmount, setConvertedAmount] = useState('0')
 
@@ -85,4 +92,43 @@ export default function useANJBalanceToUsd(amount) {
   }, [amount, anjToken, daiAddress])
 
   return convertedAmount
+}
+
+/**
+ * Convert a token into a USD price
+ *
+ * @param {String} symbol The symbol of the token to convert from.
+ * @param {Number} decimals The amount of decimals for the token.
+ * @param {BigNumber} balance The balance to convert into USD.
+ * @returns { Number } The balance value in USD
+ */
+export default function useTokenBalanceToUsd(symbol, decimals, balance) {
+  const [usd, setUsd] = useState('-')
+  useEffect(() => {
+    let cancelled = false
+
+    fetch(`${API_BASE}/price?fsym=${symbol}&tsyms=USD`)
+      .then(res => res.json())
+      .then(price => {
+        if (cancelled || !balance || !(parseFloat(price.USD) > 0)) {
+          return
+        }
+
+        const usdDigits = 2
+        const precision = 6
+
+        const usdBalance = balance
+          .mul(bigNum(parseInt(price.USD * 10 ** (precision + usdDigits), 10)))
+          .div(10 ** precision)
+          .div(bigNum(10).pow(decimals))
+
+        setUsd(formatUnits(usdBalance, { digits: usdDigits }))
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [balance, decimals, symbol])
+
+  return usd
 }

--- a/src/hooks/useTokenBalanceToUsd.js
+++ b/src/hooks/useTokenBalanceToUsd.js
@@ -3,7 +3,7 @@ import { getMarketDetails, getTokenReserves } from '@uniswap/sdk'
 import { useCourtConfig } from '../providers/CourtConfig'
 
 import env from '../environment'
-import { getTokenAddress } from '../utils/known-tokens'
+import { getKnownToken } from '../utils/known-tokens'
 import { formatUnits, bigNum } from '../lib/math-utils'
 import { addressesEqual, ETH_FAKE_ADDRESS } from '../lib/web3-utils'
 
@@ -41,7 +41,7 @@ export function useANJBalanceToUsd(amount) {
   const { anjToken } = useCourtConfig()
 
   // We'll use the ANJ <> DAI market details to get the spot price
-  const daiAddress = getTokenAddress('DAI')
+  const { address: daiAddress } = getKnownToken('DAI')
 
   const [convertedAmount, setConvertedAmount] = useState('0')
 

--- a/src/utils/known-tokens.js
+++ b/src/utils/known-tokens.js
@@ -1,10 +1,12 @@
 import env from '../environment'
 import { getNetworkName } from '../lib/web3-utils'
 
-export const KNOWN_DAI_ADDRESS_BY_ENV = {
-  mainnet: '0x6b175474e89094c44da98b954eedeac495271d0f',
+export const KNOWN_TOKEN_ADDRESS_BY_ENV = {
+  DAI: {
+    mainnet: '0x6b175474e89094c44da98b954eedeac495271d0f',
+  },
 }
 
-export function getDaiAddress() {
-  return KNOWN_DAI_ADDRESS_BY_ENV[getNetworkName(env('CHAIN_ID'))]
+export function getTokenAddress(symbol) {
+  return KNOWN_TOKEN_ADDRESS_BY_ENV[symbol][getNetworkName(env('CHAIN_ID'))]
 }

--- a/src/utils/known-tokens.js
+++ b/src/utils/known-tokens.js
@@ -5,7 +5,7 @@ export const KNOWN_TOKEN_BY_ENV = {
   DAI: {
     mainnet: {
       address: '0x6b175474e89094c44da98b954eedeac495271d0f',
-      deciamls: 18,
+      decimals: 18,
     },
   },
 }

--- a/src/utils/known-tokens.js
+++ b/src/utils/known-tokens.js
@@ -1,12 +1,15 @@
 import env from '../environment'
 import { getNetworkName } from '../lib/web3-utils'
 
-export const KNOWN_TOKEN_ADDRESS_BY_ENV = {
+export const KNOWN_TOKEN_BY_ENV = {
   DAI: {
-    mainnet: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    mainnet: {
+      address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      deciamls: 18,
+    },
   },
 }
 
-export function getTokenAddress(symbol) {
-  return KNOWN_TOKEN_ADDRESS_BY_ENV[symbol][getNetworkName(env('CHAIN_ID'))]
+export function getKnownToken(symbol) {
+  return KNOWN_TOKEN_BY_ENV[symbol][getNetworkName(env('CHAIN_ID'))]
 }


### PR DESCRIPTION
See https://github.com/aragon/court-dashboard/pull/219#discussion_r387924367

For other tokens we can directly use the `cryptocompare` api price info.
Also made `known-tokens` generic.