### PR TITLE
Disputes: show juror weight hint for jurors drafted more than once

### DIFF
--- a/src/components/Disputes/DisputeCurrentRuling.js
+++ b/src/components/Disputes/DisputeCurrentRuling.js
@@ -117,15 +117,15 @@ function DisputeCurrentRuling({ dispute }) {
                       margin-right: ${0.5 * GU}px;
                     `}
                   >
-                    {showMyWeight ? 'Your v' : 'V'}oting weight
+                    {showMyWeight ? 'Your voting weight' : 'Voting weight'}
                   </span>
-                  <Help hint="What's the voting weight?">
+                  <Help hint="">
                     {showMyWeight ? 'You have been' : 'The same juror can be'}{' '}
                     drafted multiple times to arbitrate the same dispute for the
                     same round. When that happens,{' '}
                     {showMyWeight ? 'your' : 'their'} voting weight{' '}
                     {showMyWeight ? 'is' : 'will be'} proportional to the number
-                    of times {showMyWeight ? 'you are' : 'is'} drafted.
+                    of times {showMyWeight ? 'you' : 'they'} are drafted.
                   </Help>
                 </div>
               )}

--- a/src/components/Disputes/DisputeCurrentRuling.js
+++ b/src/components/Disputes/DisputeCurrentRuling.js
@@ -123,7 +123,7 @@ function DisputeCurrentRuling({ dispute }) {
                     the same dispute for the same round. When that happens,
                     their voting weight will be proportional to the number of
                     times is drafted, as well as the % of ANJ locked in the
-                    Active balance.{' '}
+                    Active balance.
                   </Help>
                 </div>
               )}

--- a/src/components/Disputes/DisputeCurrentRuling.js
+++ b/src/components/Disputes/DisputeCurrentRuling.js
@@ -56,9 +56,10 @@ function DisputeCurrentRuling({ dispute }) {
           percentage: weight,
         }))}
         renderFullLegendItem={({ color, item, index, percentage }) => {
-          // We'll show the juror voting weight hint only if the juror participated in the  current ruling
-          // and has been drafted more than once
-          const showMyVotingWeight = index === 0 && myWeight > 1
+          // We'll show the juror voting weight hint if any juror has been drafted more than once for this last round
+          const showVotingWeightHint =
+            index === 0 && lastRound.jurorsNumber !== lastRound.jurors.length
+          const showMyWeight = myWeight > 1
 
           return (
             <div
@@ -80,7 +81,7 @@ function DisputeCurrentRuling({ dispute }) {
                     background: ${color};
                     width: 8px;
                     height: 8px;
-                    margin-right: 8px;
+                    margin-right: ${1 * GU}px;
                     border-radius: 50%;
                   `}
                 />
@@ -103,7 +104,7 @@ function DisputeCurrentRuling({ dispute }) {
                 </span>
                 {myDistributionIndex === index && <Tag>You</Tag>}
               </div>
-              {showMyVotingWeight && (
+              {showVotingWeightHint && (
                 <div
                   css={`
                     display: flex;
@@ -116,14 +117,15 @@ function DisputeCurrentRuling({ dispute }) {
                       margin-right: ${0.5 * GU}px;
                     `}
                   >
-                    Your voting weight
+                    {showMyWeight ? 'Your v' : 'V'}oting weight
                   </span>
-                  <Help>
-                    The same juror can be drafted multiple times to arbitrate
-                    the same dispute for the same round. When that happens,
-                    their voting weight will be proportional to the number of
-                    times is drafted, as well as the % of ANJ locked in the
-                    Active balance.
+                  <Help hint="What's the voting weight?">
+                    {showMyWeight ? 'You have been' : 'The same juror can be'}{' '}
+                    drafted multiple times to arbitrate the same dispute for the
+                    same round. When that happens,{' '}
+                    {showMyWeight ? 'your' : 'their'} voting weight{' '}
+                    {showMyWeight ? 'is' : 'will be'} proportional to the number
+                    of times {showMyWeight ? 'you are' : 'is'} drafted.
                   </Help>
                 </div>
               )}

--- a/src/components/Disputes/DisputeCurrentRuling.js
+++ b/src/components/Disputes/DisputeCurrentRuling.js
@@ -26,7 +26,7 @@ function DisputeCurrentRuling({ dispute }) {
   const lastRound = getDisputeLastRound(dispute)
   const jurorDraft = getJurorDraft(lastRound, wallet.account)
 
-  const { outcome: myOutcome = 0 } = jurorDraft || {}
+  const { outcome: myOutcome = 0, weight: myWeight = 0 } = jurorDraft || {}
   const distribution = useOutcomeDistribution(lastRound)
 
   // distribution is sorted by weight so we can return colors in corresponding order
@@ -57,7 +57,8 @@ function DisputeCurrentRuling({ dispute }) {
         }))}
         renderFullLegendItem={({ color, item, index, percentage }) => {
           // We'll show the juror voting weight hint only if the juror participated in the  current ruling
-          const showMyVotingWeight = myDistributionIndex >= 0 && index === 0
+          // and has been drafted more than once
+          const showMyVotingWeight = myWeight > 1 && index === 0
 
           return (
             <div

--- a/src/components/Disputes/DisputeCurrentRuling.js
+++ b/src/components/Disputes/DisputeCurrentRuling.js
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { Distribution, GU, Tag, textStyle, useTheme } from '@aragon/ui'
+import { Distribution, GU, Help, Tag, textStyle, useTheme } from '@aragon/ui'
 import { useWallet } from '../../providers/Wallet'
 import {
   isValidOutcome,
@@ -55,42 +55,80 @@ function DisputeCurrentRuling({ dispute }) {
           item: juryOutcomeToString(outcome),
           percentage: weight,
         }))}
-        renderFullLegendItem={({ color, item, index, percentage }) => (
-          <div
-            css={`
-              display: flex;
-              align-items: center;
-            `}
-          >
+        renderFullLegendItem={({ color, item, index, percentage }) => {
+          // We'll show the juror voting weight hint only if the juror participated in the  current ruling
+          const showMyVotingWeight = myDistributionIndex >= 0 && index === 0
+
+          return (
             <div
               css={`
-                background: ${color};
-                width: 8px;
-                height: 8px;
-                margin-right: 8px;
-                border-radius: 50%;
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                width: 100%;
               `}
-            />
+            >
+              <div
+                css={`
+                  display: flex;
+                  align-items: center;
+                `}
+              >
+                <div
+                  css={`
+                    background: ${color};
+                    width: 8px;
+                    height: 8px;
+                    margin-right: 8px;
+                    border-radius: 50%;
+                  `}
+                />
 
-            <span
-              key={index}
-              css={`
-                color: ${theme.contentSecondary};
-                width: 220px;
-              `}
-            >
-              {item}
-            </span>
-            <span
-              css={`
-                margin-right: ${1 * GU}px;
-              `}
-            >
-              {percentage}%
-            </span>
-            {myDistributionIndex === index && <Tag>You</Tag>}
-          </div>
-        )}
+                <span
+                  key={index}
+                  css={`
+                    color: ${theme.contentSecondary};
+                    width: 220px;
+                  `}
+                >
+                  {item}
+                </span>
+                <span
+                  css={`
+                    margin-right: ${1 * GU}px;
+                  `}
+                >
+                  {percentage}%
+                </span>
+                {myDistributionIndex === index && <Tag>You</Tag>}
+              </div>
+              {showMyVotingWeight && (
+                <div
+                  css={`
+                    display: flex;
+                    align-items: center;
+                  `}
+                >
+                  <span
+                    css={`
+                      color: ${theme.help};
+                      margin-right: ${0.5 * GU}px;
+                    `}
+                  >
+                    Your voting weight
+                  </span>
+                  <Help>
+                    The same juror can be drafted multiple times to arbitrate
+                    the same dispute for the same round. When that happens,
+                    their voting weight will be proportional to the number of
+                    times is drafted, as well as the % of ANJ locked in the
+                    Active balance.{' '}
+                  </Help>
+                </div>
+              )}
+            </div>
+          )
+        }}
         colors={colors}
       />
     </div>

--- a/src/components/Disputes/DisputeCurrentRuling.js
+++ b/src/components/Disputes/DisputeCurrentRuling.js
@@ -58,7 +58,7 @@ function DisputeCurrentRuling({ dispute }) {
         renderFullLegendItem={({ color, item, index, percentage }) => {
           // We'll show the juror voting weight hint only if the juror participated in the  current ruling
           // and has been drafted more than once
-          const showMyVotingWeight = myWeight > 1 && index === 0
+          const showMyVotingWeight = index === 0 && myWeight > 1
 
           return (
             <div


### PR DESCRIPTION
closes #236 

When implementing this, i wondered whether we should also show this hint in the voting phase.
What do you think?

**Preview:** 

![Screen Shot 2020-03-20 at 9 13 21 PM](https://user-images.githubusercontent.com/22663232/77215141-65743a80-6af1-11ea-944e-151f02914a1a.png)
![Screen Shot 2020-03-20 at 9 13 26 PM](https://user-images.githubusercontent.com/22663232/77215142-673dfe00-6af1-11ea-98e4-e28d79c7c50f.png)
