### PR TITLE
Refactor: Court subscriptions and treasury balances query

### DIFF
--- a/src/components/Activity/activity-types.js
+++ b/src/components/Activity/activity-types.js
@@ -56,6 +56,15 @@ const ACTIVITY_TYPES = new Map(
         `,
       }
     },
+    claimSubscriptionFees({ periodId }) {
+      return {
+        title: 'Claim Subscription rewards',
+        icon: iconClaimRewards,
+        description: `
+          Claim subscription rewards for period ${periodId}
+        `,
+      }
+    },
     commitVote({ disputeId, roundId, commitment }) {
       return {
         title: 'Commit vote',

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -28,8 +28,8 @@ function Dashboard() {
   const wallet = useWallet()
   const {
     actions,
+    anjBalances,
     appealCollaterals,
-    balances,
     errorsFetching,
     fetchingData,
     mode,
@@ -54,7 +54,7 @@ function Dashboard() {
         <>
           {wallet.account ? (
             <BalanceModule
-              balances={balances}
+              balances={anjBalances}
               loading={fetchingData}
               onRequestActivate={requests.activateANJ}
               onRequestDeactivate={requests.deactivateANJ}
@@ -106,7 +106,7 @@ function Dashboard() {
         <PanelComponent
           mode={mode}
           actions={actions}
-          balances={balances}
+          balances={anjBalances}
           onDone={panelState.requestClose}
         />
       </SidePanel>

--- a/src/components/Dashboard/DashboardStateProvider.js
+++ b/src/components/Dashboard/DashboardStateProvider.js
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react'
 import { useWallet } from '../../providers/Wallet'
 import {
-  useJurorBalancesSubscription,
   useAppealsByUserSubscription,
+  useJurorBalancesSubscription,
   useJurorDraftsNotRewardedSubscription,
 } from '../../hooks/subscription-hooks'
 
@@ -22,17 +22,27 @@ function DashboardStateProvider({ children }) {
     )
 
   return (
-    <Provider value={{ balances: {}, anjMovements: [], nonSettledAppeals: [] }}>
+    <Provider
+      value={{
+        anjMovements: [],
+        anjBalances: {},
+        appeals: [],
+        claimedSubscriptionFees: [],
+        jurorDrafts: [],
+        treasury: [],
+      }}
+    >
       {children}
     </Provider>
   )
 }
 
 function WithSubscription({ Provider, connectedAccount, children }) {
-  // Juror balances
+  // Juror ANJ balances, 24h ANJ movements and claimed subscription fees
   const {
-    balances,
+    anjBalances,
     anjMovements,
+    claimedSubscriptionFees,
     treasury,
     fetching: balancesFetching,
     errors: balanceErrors,
@@ -45,7 +55,7 @@ function WithSubscription({ Provider, connectedAccount, children }) {
     errors: appealErrors,
   } = useAppealsByUserSubscription(connectedAccount, false) // Non settled appeals
 
-  // juror drafts not rewarded
+  // Juror drafts not rewarded
   const {
     jurorDrafts,
     fetching: jurorDraftsFetching,
@@ -62,12 +72,13 @@ function WithSubscription({ Provider, connectedAccount, children }) {
   return (
     <Provider
       value={{
+        anjBalances,
+        anjMovements,
         appeals,
-        balances,
+        claimedSubscriptionFees,
         errors,
         fetching,
         jurorDrafts,
-        anjMovements,
         treasury,
       }}
     >

--- a/src/components/Dashboard/RewardsModule.js
+++ b/src/components/Dashboard/RewardsModule.js
@@ -58,7 +58,7 @@ const RewardsModule = React.memo(function RewardsModule({
   const { feeToken } = useCourtConfig()
 
   // Subscriptions are fetched directly from the subscriptions contract
-  const [subscriptionFees, setSubscriptionFees] = useJurorSubscriptionFees()
+  const subscriptionFees = useJurorSubscriptionFees()
   const { anjRewards, feeRewards } = rewards || {}
 
   const {
@@ -130,8 +130,6 @@ const RewardsModule = React.memo(function RewardsModule({
         }
 
         await Promise.all(rewardTransactionQueue.map(tx => tx.wait()))
-
-        setSubscriptionFees([])
       } catch (err) {
         console.error(`Error claiming rewards: ${err}`)
         Sentry.captureException(err)
@@ -145,7 +143,6 @@ const RewardsModule = React.memo(function RewardsModule({
       onSettleReward,
       onWithdraw,
       rewards,
-      setSubscriptionFees,
       subscriptionFees,
       totalTreasuryFees,
       wallet.account,

--- a/src/dashboard-logic.js
+++ b/src/dashboard-logic.js
@@ -74,7 +74,7 @@ export function useDashboardLogic() {
   } = useANJActions()
 
   const rewards = useJurorRewards()
-  const balances = useANJBalances()
+  const anjBalances = useANJBalances()
   const panelState = useSidePanel()
 
   const appealCollaterals = useJurorAppealCollaterals()
@@ -102,8 +102,8 @@ export function useDashboardLogic() {
 
   return {
     actions,
+    anjBalances,
     appealCollaterals,
-    balances,
     errorsFetching,
     fetchingData,
     mode,

--- a/src/hooks/query-hooks.js
+++ b/src/hooks/query-hooks.js
@@ -21,7 +21,8 @@ export function useJurorDraftQuery(jurorId) {
 }
 
 /**
- * Queries if juror has ever claimed any rewards
+ * Queries if the juror  by id `jurorId` has already claimed rewards
+ * Rewards can be claimed from two places: Subscriptions fees or Dispute fees (the later includes appeal and juror fees)
  *
  * @param {String} jurorId Address of the juror
  * @returns {Boolean} True if juror has already claimed rewards
@@ -29,19 +30,14 @@ export function useJurorDraftQuery(jurorId) {
 export function useJurorRewardsClaimedQuery(jurorId) {
   const [{ data }] = useQuery({
     query: JurorFeesClaimed,
-    variables: { id: jurorId.toLowerCase() },
+    variables: { owner: jurorId.toLowerCase() },
   })
 
-  if (!data || !data.juror) {
+  if (!data) {
     return false
   }
 
-  const {
-    drafts: rewardedDrafts,
-    feeMovements: claimedSubscriptionFeeMovements,
-  } = data.juror
-
-  return rewardedDrafts.length > 0 || claimedSubscriptionFeeMovements.length > 0
+  return data.feeMovements.length > 0
 }
 
 export function useFirstANJActivationQuery(jurorId, { pause = false }) {

--- a/src/hooks/useANJ.js
+++ b/src/hooks/useANJ.js
@@ -20,7 +20,7 @@ import { getDraftLockAmount } from '../utils/dispute-utils'
 import { ANJBalance, ANJMovement } from '../types/anj-types'
 
 export function useANJBalances() {
-  const { balances, anjMovements } = useDashboardState()
+  const { anjBalances, anjMovements } = useDashboardState()
 
   const {
     walletBalance,
@@ -28,7 +28,7 @@ export function useANJBalances() {
     lockedBalance,
     inactiveBalance,
     deactivationBalance,
-  } = balances || {}
+  } = anjBalances || {}
 
   const convertedMovements = useConvertedMovements(anjMovements)
 
@@ -62,7 +62,7 @@ export function useANJBalances() {
 
   // Since we pass the whole object through props to components, we should memoize it
   return useMemo(() => {
-    if (!balances) {
+    if (!anjBalances) {
       return null
     }
 
@@ -74,7 +74,7 @@ export function useANJBalances() {
       deactivationBalance: convertedDeactivationBalance,
     }
   }, [
-    balances,
+    anjBalances,
     convertedActiveBalance,
     convertedDeactivationBalance,
     convertedInactiveBalance,
@@ -144,8 +144,8 @@ function useConvertedMovements(movements) {
  * @returns {Object} Converted balance
  */
 function useBalanceWithMovements(balance, movements, balanceType) {
-  const { balances } = useDashboardState()
-  const { lockedBalance } = balances || {}
+  const { anjBalances } = useDashboardState()
+  const { lockedBalance } = anjBalances || {}
 
   const acceptedMovements = acceptedMovementsPerBalance.get(balanceType)
   const filteredMovements = useFilteredMovements(movements, acceptedMovements)
@@ -226,8 +226,8 @@ export function useJurorLockedANJDistribution() {
     minActiveBalance,
     penaltyPct,
   } = useCourtConfig()
-  const { jurorDrafts, balances } = useDashboardState()
-  const { lockedBalance } = balances || {}
+  const { jurorDrafts, anjBalances } = useDashboardState()
+  const { lockedBalance } = anjBalances || {}
 
   return useMemo(() => {
     if (!lockedBalance || lockedBalance.eq(0) || !jurorDrafts) return null

--- a/src/hooks/useCourtContracts.js
+++ b/src/hooks/useCourtContracts.js
@@ -338,6 +338,7 @@ export function useRewardActions() {
 }
 
 export function useCourtSubscriptionActions() {
+  const { addActivity } = useActivity()
   const courtSubscriptionsContract = useCourtContract(
     CourtModuleType.Subscriptions,
     courtSubscriptionsAbi
@@ -345,14 +346,14 @@ export function useCourtSubscriptionActions() {
 
   const claimFees = useCallback(
     periodId => {
-      return courtSubscriptionsContract.claimFees(periodId)
+      return addActivity(
+        courtSubscriptionsContract.claimFees(periodId),
+        'claimSubscriptionFees',
+        { periodId }
+      )
     },
-    [courtSubscriptionsContract]
+    [addActivity, courtSubscriptionsContract]
   )
-
-  const getCurrentPeriodId = useCallback(() => {
-    return courtSubscriptionsContract.getCurrentPeriodId()
-  }, [courtSubscriptionsContract])
 
   const getJurorShare = useCallback(
     (juror, periodId) => {
@@ -361,24 +362,9 @@ export function useCourtSubscriptionActions() {
     [courtSubscriptionsContract]
   )
 
-  const hasJurorClaimed = useCallback(
-    (juror, periodId) => {
-      return courtSubscriptionsContract.hasJurorClaimed(juror, periodId)
-    },
-    [courtSubscriptionsContract]
-  )
-
   const getters = useMemo(
-    () =>
-      courtSubscriptionsContract
-        ? { getCurrentPeriodId, getJurorShare, hasJurorClaimed }
-        : null,
-    [
-      courtSubscriptionsContract,
-      getCurrentPeriodId,
-      getJurorShare,
-      hasJurorClaimed,
-    ]
+    () => (courtSubscriptionsContract ? { getJurorShare } : null),
+    [courtSubscriptionsContract, getJurorShare]
   )
 
   return {

--- a/src/networks.js
+++ b/src/networks.js
@@ -10,7 +10,7 @@ export const RINKEBY_STAGING_COURT =
   '0xd0dcfc6b5b36f7e77f3daa2d9031b241651a6916'
 
 export const networks = {
-  rpc: { court: '0xD833215cBcc3f914bD1C9ece3EE7BF8B14f841bb' },
+  rpc: { court: '0xC89Ce4735882C9F0f0FE26686c53074E09B0D550' },
   ropsten: { court: '0x3b26bc496aebaed5b3E0E81cDE6B582CDe71396e' },
   rinkeby: {
     // Use the 'usability' Court address if declared

--- a/src/networks.js
+++ b/src/networks.js
@@ -10,7 +10,7 @@ export const RINKEBY_STAGING_COURT =
   '0xd0dcfc6b5b36f7e77f3daa2d9031b241651a6916'
 
 export const networks = {
-  rpc: { court: '0xC89Ce4735882C9F0f0FE26686c53074E09B0D550' },
+  rpc: { court: '0xD833215cBcc3f914bD1C9ece3EE7BF8B14f841bb' },
   ropsten: { court: '0x3b26bc496aebaed5b3E0E81cDE6B582CDe71396e' },
   rinkeby: {
     // Use the 'usability' Court address if declared

--- a/src/providers/CourtConfig.js
+++ b/src/providers/CourtConfig.js
@@ -4,7 +4,6 @@ import environment from '../environment'
 import { useCourtConfigSubscription } from '../hooks/subscription-hooks'
 import { getNetworkType } from '../lib/web3-utils'
 import { networks } from '../networks'
-import { bigNum } from '../lib/math-utils'
 
 const CHAIN_ID = environment('CHAIN_ID')
 const CourtConfigContext = React.createContext()
@@ -13,36 +12,8 @@ function CourtConfigProvider({ children }) {
   const courtAddress = networks[getNetworkType(CHAIN_ID)].court
   const courtConfig = useCourtConfigSubscription(courtAddress)
 
-  const convertedCourtConfig = courtConfig
-    ? {
-        ...courtConfig, // TODO: Move data conversion to subscription handler
-        draftFee: bigNum(courtConfig.draftFee),
-        settleFee: bigNum(courtConfig.settleFee),
-        jurorFee: bigNum(courtConfig.jurorFee),
-        minActiveBalance: bigNum(courtConfig.minActiveBalance),
-        maxRegularAppealRounds: parseInt(
-          courtConfig.maxRegularAppealRounds,
-          10
-        ),
-        termDuration: parseInt(courtConfig.termDuration, 10) * 1000,
-        currentTerm: parseInt(courtConfig.currentTerm, 10),
-        evidenceTerms: parseInt(courtConfig.evidenceTerms, 10),
-        commitTerms: parseInt(courtConfig.commitTerms, 10),
-        revealTerms: parseInt(courtConfig.revealTerms, 10),
-        appealTerms: parseInt(courtConfig.appealTerms, 10),
-        appealConfirmationTerms: parseInt(
-          courtConfig.appealConfirmationTerms,
-          10
-        ),
-        terms: courtConfig.terms.map(term => ({
-          ...term,
-          startTime: parseInt(term.startTime, 10) * 1000,
-        })),
-      }
-    : null
-
   return (
-    <CourtConfigContext.Provider value={convertedCourtConfig}>
+    <CourtConfigContext.Provider value={courtConfig}>
       {children}
     </CourtConfigContext.Provider>
   )

--- a/src/queries/balances.js
+++ b/src/queries/balances.js
@@ -16,15 +16,6 @@ export const Juror = gql`
       availableBalance
       deactivationBalance
       withdrawalsLockTermId
-      treasuryBalances {
-        token {
-          id
-          name
-          symbol
-          decimals
-        }
-        amount
-      }
       anjMovements(
         orderBy: createdAt
         orderDirection: desc
@@ -35,6 +26,23 @@ export const Juror = gql`
         createdAt
         type
       }
+      claimedSubscriptionFees {
+        id
+        period {
+          id
+        }
+      }
+    }
+  }
+`
+
+export const JurorTreasuryBalances = gql`
+  subscription JurorTreasuryBalances($owner: Bytes!) {
+    treasuryBalances(where: { owner: $owner }) {
+      token {
+        id
+      }
+      amount
     }
   }
 `

--- a/src/queries/court.js
+++ b/src/queries/court.js
@@ -39,6 +39,18 @@ export const CourtConfig = gql`
       appealConfirmCollateralFactor
       minActiveBalance
       penaltyPct
+      subscriptions {
+        id
+        currentPeriod
+        feeAmount
+        periodDuration
+        periods {
+          id
+          balanceCheckpoint
+          totalActiveBalance
+          collectedFees
+        }
+      }
       modules {
         type
         address

--- a/src/queries/juror.js
+++ b/src/queries/juror.js
@@ -2,15 +2,9 @@ import gql from 'graphql-tag'
 
 // First juror subscription claimed
 export const JurorFeesClaimed = gql`
-  query Juror($id: ID!) {
-    juror(id: $id) {
+  query JurorFeesClaimed($owner: Bytes!) {
+    feeMovements(where: { owner: $owner }) {
       id
-      drafts(where: { rewarded: true }, first: 1) {
-        id
-      }
-      feeMovements(type: "Subscriptions", first: 1) {
-        id
-      }
     }
   }
 `

--- a/src/utils/court-utils.js
+++ b/src/utils/court-utils.js
@@ -1,4 +1,32 @@
 import { CourtModuleType } from '../types/court-module-types'
+import { bigNum } from '../lib/math-utils'
+import { transformSubscriptionModuleDataAttributes } from './subscription-utils'
+
+export function transformCourtConfigDataAttributes(courtConfig) {
+  const { subscriptions: subscriptionModule } = courtConfig
+  return {
+    ...courtConfig,
+    draftFee: bigNum(courtConfig.draftFee),
+    settleFee: bigNum(courtConfig.settleFee),
+    jurorFee: bigNum(courtConfig.jurorFee),
+    minActiveBalance: bigNum(courtConfig.minActiveBalance),
+    maxRegularAppealRounds: parseInt(courtConfig.maxRegularAppealRounds, 10),
+    termDuration: parseInt(courtConfig.termDuration, 10) * 1000,
+    currentTerm: parseInt(courtConfig.currentTerm, 10),
+    evidenceTerms: parseInt(courtConfig.evidenceTerms, 10),
+    commitTerms: parseInt(courtConfig.commitTerms, 10),
+    revealTerms: parseInt(courtConfig.revealTerms, 10),
+    appealTerms: parseInt(courtConfig.appealTerms, 10),
+    appealConfirmationTerms: parseInt(courtConfig.appealConfirmationTerms, 10),
+    terms: courtConfig.terms.map(term => ({
+      ...term,
+      startTime: parseInt(term.startTime, 10) * 1000,
+    })),
+    subscriptionModule: transformSubscriptionModuleDataAttributes(
+      subscriptionModule
+    ),
+  }
+}
 
 function getFirstTermDate(courtConfig) {
   const { terms } = courtConfig

--- a/src/utils/dispute-utils.js
+++ b/src/utils/dispute-utils.js
@@ -8,7 +8,7 @@ import { getVoidedDisputesByCourt } from '../voided-disputes'
 export const FINAL_ROUND_WEIGHT_PRECISION = bigNum(1000)
 export const PCT_BASE = bigNum(10000)
 
-export const transformResponseDisputeAttributes = dispute => {
+export const transformDisputeDataAttributes = dispute => {
   const transformedDispute = {
     ...dispute,
     createdAt: parseInt(dispute.createdAt, 10) * 1000,

--- a/src/utils/subscription-utils.js
+++ b/src/utils/subscription-utils.js
@@ -1,0 +1,29 @@
+import { bigNum } from '../lib/math-utils'
+
+export function transformSubscriptionModuleDataAttributes(subscriptionModule) {
+  return {
+    ...subscriptionModule,
+    currentPeriod: parseInt(subscriptionModule.currentPeriod, 10),
+    feeAmount: bigNum(subscriptionModule.feeAmount),
+    periodDuration: parseInt(subscriptionModule.periodDuration) * 1000,
+    periods: subscriptionModule.periods.map(period => ({
+      ...period,
+      id: parseInt(period.id, 10),
+      totalActiveBalance: period.totalActiveBalance,
+      collectedFees: bigNum(period.collectedFees),
+    })),
+  }
+}
+
+export function transformClaimedFeesDataAttributes(claimedFee) {
+  return {
+    ...claimedFee,
+    period: {
+      id: parseInt(claimedFee.period.id, 10),
+    },
+  }
+}
+
+export function hasJurorClaimed(claimedFees, periodId) {
+  return claimedFees.some(claimedFee => claimedFee.period.id === periodId)
+}


### PR DESCRIPTION
Now that we have available the `subscriptionModule` at the subgraph, we can now drop most of the contract calls (we must still use `getJurorShare`)  and improve performance.

This PR also includes changes on the way we request an account treasury balances and contemplates latest changes made by @facuspagnuolo here https://github.com/aragon/court-subgraph/pull/53