### PR TITLE
Activity Module: Update account's activities when empty

### DIFF
--- a/src/components/Activity/ActivityProvider.js
+++ b/src/components/Activity/ActivityProvider.js
@@ -190,17 +190,19 @@ function ActivityProvider({ children }) {
       return
     }
 
-    const activitiesFromStorage = storedList.current
-      .getItems()
-      .filter(({ transactionHash }) => {
-        return (
+    const activitiesFromStorage = storedList.current.getItems()
+
+    // We will diff activities from storage and activites from state to prevent loops in the useEffect below
+    const activitiesChanged =
+      activities.length !== activitiesFromStorage.length ||
+      activitiesFromStorage.filter(
+        ({ transactionHash }) =>
           activities.findIndex(
             activity => activity.transactionHash === transactionHash
           ) === -1
-        )
-      })
+      ) > 0
 
-    if (activitiesFromStorage.length > 0) {
+    if (activitiesChanged) {
       setActivities(activitiesFromStorage)
     }
   }, [activities])


### PR DESCRIPTION
We had a minor issue in the activity provider where we weren't handling the cases between when an account that has activities stored, changes to an account which doesn't have any.