### PR TITLE
`useCourtContracts`: Invalid address fix.

### DIFF
--- a/src/hooks/useCourtContracts.js
+++ b/src/hooks/useCourtContracts.js
@@ -583,7 +583,11 @@ export function useTotalANTStakedPolling(timeout = 1000) {
     let timeoutId
 
     // Since we don't have the ANT contract address on the local environment we are skipping the stat
-    if (isLocalOrUnknownNetwork()) {
+    if (
+      isLocalOrUnknownNetwork() ||
+      !networkAgentAddress ||
+      !networkReserveAddress
+    ) {
       setError(true)
       return
     }

--- a/src/hooks/useCourtContracts.js
+++ b/src/hooks/useCourtContracts.js
@@ -579,7 +579,7 @@ export function useTotalANTStakedPolling(timeout = 1000) {
     let cancelled = false
     let timeoutId
 
-    // We won't be using this stats other than from mainnet network
+    // This stat is only relevant and shown on mainnet
     if (!networkAgentAddress || !networkReserveAddress) {
       return setError(true)
     }

--- a/src/hooks/useCourtContracts.js
+++ b/src/hooks/useCourtContracts.js
@@ -582,15 +582,11 @@ export function useTotalANTStakedPolling(timeout = 1000) {
     let cancelled = false
     let timeoutId
 
-    // Since we don't have the ANT contract address on the local environment we are skipping the stat
-    if (
-      isLocalOrUnknownNetwork() ||
-      !networkAgentAddress ||
-      !networkReserveAddress
-    ) {
-      setError(true)
-      return
+    // We won't be using this stats other than from mainnet network
+    if (!networkAgentAddress || !networkReserveAddress) {
+      return setError(true)
     }
+
     if (!antContract) {
       return
     }

--- a/src/hooks/useCourtContracts.js
+++ b/src/hooks/useCourtContracts.js
@@ -3,10 +3,7 @@ import { captureException } from '@sentry/browser'
 import { CourtModuleType } from '../types/court-module-types'
 import { useContract, useContractReadOnly } from '../web3-contracts'
 import { useCourtConfig } from '../providers/CourtConfig'
-import {
-  getFunctionSignature,
-  isLocalOrUnknownNetwork,
-} from '../lib/web3-utils'
+import { getFunctionSignature } from '../lib/web3-utils'
 import { bigNum, formatUnits } from '../lib/math-utils'
 import {
   hashVote,


### PR DESCRIPTION
Closes #271 

We won't be using total ANT staked for networks that aren't mainnet.