### PR TITLE
Clock Module: Disable heartbeat action when court has not fully loaded

### DIFF
--- a/src/components/ClockModule.js
+++ b/src/components/ClockModule.js
@@ -275,7 +275,7 @@ function ClockModule() {
                 label="Update term"
                 mode="strong"
                 wide
-                disabled={!wallet.account}
+                disabled={!courtConfig || !wallet.account}
                 onClick={handleOnClick}
               />
             )}


### PR DESCRIPTION
Sometimes, fetching the court data from the subgraph, takes longer than expected.
In this situations, users seem to try to heartbeat the court thinking it could be out of sync.

This PR disables the heartbeat action button if the court configuration has not been fetched and mitigates the issue at https://sentry.io/share/issue/2b43c8bd402f422dbd9b130817ed7d7c/.

