### PR TITLE
DisputeTimeline: Fix drafted date

### DIFF
--- a/src/utils/dispute-utils.js
+++ b/src/utils/dispute-utils.js
@@ -381,8 +381,9 @@ function getRoundPhasesAndTime(courtConfig, round, currentPhase) {
     ]
   }
 
-  const votingEndTime =
-    disputeDraftStartTime + termDuration * (delayedTerms + commitTerms)
+  const disputeDraftEndTime =
+    disputeDraftStartTime + termDuration * delayedTerms
+  const votingEndTime = disputeDraftEndTime + termDuration * commitTerms
   const revealEndTime = votingEndTime + termDuration * revealTerms
   const appealEndTime = revealEndTime + termDuration * appealTerms
   const confirmAppealEndTime =
@@ -393,8 +394,13 @@ function getRoundPhasesAndTime(courtConfig, round, currentPhase) {
 
   const roundPhasesAndTime = [
     {
-      // Jurors can be drafted at any time
+      // Jurors can be drafted at any time, so we'll only set the
+      // `endTime` when the drafting phase has already passed
       phase: DisputesTypes.Phase.JuryDrafting,
+      endTime:
+        DisputesTypes.Phase.JuryDrafting !== currentPhase.phase
+          ? disputeDraftEndTime
+          : null,
       active:
         isCurrentRound &&
         DisputesTypes.Phase.JuryDrafting === currentPhase.phase,


### PR DESCRIPTION
Noticed that the drafted date was off in the dispute timeline.

- Sets the `endTime` on the draft phase only after it has passed.

**Before:**
<img width="279" alt="Screen Shot 2020-05-16 at 8 16 49 PM" src="https://user-images.githubusercontent.com/22663232/82132180-53421000-97b3-11ea-93de-712855cbf055.png">

**After:** 
<img width="279" alt="Screen Shot 2020-05-16 at 8 20 44 PM" src="https://user-images.githubusercontent.com/22663232/82132182-5dfca500-97b3-11ea-8dd5-6e4f650aa740.png">

