### PR TITLE
AccountModule: Fix providers height bug

### DIFF
--- a/src/components/Account/AccountModule.js
+++ b/src/components/Account/AccountModule.js
@@ -10,20 +10,13 @@ import ScreenConnecting from './ScreenConnecting'
 import ScreenError from './ScreenError'
 import ScreenProviders from './ScreenProviders'
 
-const NUM_OF_PROVIDERS = getUseWalletProviders().length
-
 const SCREENS = [
   {
     id: 'providers',
     title: 'Ethereum providers',
     height:
       4 * GU + // header
-      (12 + 1.5) *
-        GU *
-        ((NUM_OF_PROVIDERS % 2 !== 0
-          ? NUM_OF_PROVIDERS + 1
-          : NUM_OF_PROVIDERS) /
-          2) + // buttons
+      (12 + 1.5) * GU * Math.ceil(getUseWalletProviders().length / 2) + // buttons
       7 * GU, // footer
   },
   {

--- a/src/components/Account/AccountModule.js
+++ b/src/components/Account/AccountModule.js
@@ -10,13 +10,20 @@ import ScreenConnecting from './ScreenConnecting'
 import ScreenError from './ScreenError'
 import ScreenProviders from './ScreenProviders'
 
+const NUM_OF_PROVIDERS = getUseWalletProviders().length
+
 const SCREENS = [
   {
     id: 'providers',
     title: 'Ethereum providers',
     height:
       4 * GU + // header
-      (12 + 1.5) * GU * (getUseWalletProviders().length / 2) + // buttons
+      (12 + 1.5) *
+        GU *
+        ((NUM_OF_PROVIDERS % 2 !== 0
+          ? NUM_OF_PROVIDERS + 1
+          : NUM_OF_PROVIDERS) /
+          2) + // buttons
       7 * GU, // footer
   },
   {


### PR DESCRIPTION
Fixes a bug regarding the Account Module and an uneven number of providers.

**How can this happen?**
Right now, the way we're calculating the height for the popover is adding the header and footer height, and then dynamically calculating the height for the providers depending on how many they are. While it's not shown on the court dashboard as we have an even number of providers, this can be seen as soon as we set an uneven number of them (e.g removing Portis or Fortmatic).

The fix is just to always make the number of providers even so height is always properly calculated.