### PR TITLE
Remove "irreversibly" from unsubscribe copy

### DIFF
--- a/src/components/EmailNotifications/DeleteEmail.js
+++ b/src/components/EmailNotifications/DeleteEmail.js
@@ -55,9 +55,9 @@ const DeleteEmail = React.memo(function DeleteEmail({
             margin-top: ${1.5 * GU}px;
           `}
         >
-          This action will unsubscribe you from all email
-          notifications and remove this email address from our databases. You
-          can always re-subscribe from the notifications preferences later.
+          This action will unsubscribe you from all email notifications and
+          remove this email address from our databases. You can always
+          re-subscribe from the notifications preferences later.
         </span>
         <div
           css={`

--- a/src/components/EmailNotifications/DeleteEmail.js
+++ b/src/components/EmailNotifications/DeleteEmail.js
@@ -55,7 +55,7 @@ const DeleteEmail = React.memo(function DeleteEmail({
             margin-top: ${1.5 * GU}px;
           `}
         >
-          This action will irreversibly unsubscribe you from all email
+          This action will unsubscribe you from all email
           notifications and remove this email address from our databases. You
           can always re-subscribe from the notifications preferences later.
         </span>


### PR DESCRIPTION
- Calling this action "irreversible" is inaccurate, and is even contradicted in the next sentence: "You can always re-subscribe from the notifications preferences later."