### PR TITLE
Balance Module: Update latest movement message when not effective

### DIFF
--- a/src/components/Dashboard/Balance.js
+++ b/src/components/Dashboard/Balance.js
@@ -17,13 +17,13 @@ import ANJIcon from '../../assets/IconANJ.svg'
 import lockIcon from '../../assets/IconLock.svg'
 
 const Balance = React.memo(function Balance({
-  label,
   amount,
-  loading,
   actions,
-  mainIcon,
   activity,
   distribution,
+  label,
+  loading,
+  mainIcon,
   mainIconBackground,
 }) {
   const theme = useTheme()
@@ -76,11 +76,11 @@ const Balance = React.memo(function Balance({
             </div>
             <div>
               <span
-                css={`      
-                ${textStyle('body2')}
-                color: ${theme.surfaceContentSecondary};
-                display:block;
-              `}
+                css={`
+                  ${textStyle('body2')};
+                  color: ${theme.surfaceContentSecondary};
+                  display: block;
+                `}
               >
                 {label}
               </span>
@@ -99,10 +99,10 @@ const Balance = React.memo(function Balance({
               </div>
               <span
                 css={`
-                ${textStyle('body4')}
-                color: ${theme.surfaceContentSecondary};
-                display:block;
-              `}
+                  ${textStyle('body4')};
+                  color: ${theme.surfaceContentSecondary};
+                  display: block;
+                `}
               >
                 $ {convertedAmount}
               </span>
@@ -218,7 +218,9 @@ const LatestActivity = ({ activity, distribution }) => {
             color: ${theme.content};
           `}
         >
-          {convertToString(activity.type, activity.direction)}
+          {activity.isImmediate && !activity.isEffective
+            ? 'Effective next term'
+            : convertToString(activity.type, activity.direction)}
         </span>
       </div>
       {distribution && <ANJLockedHelp distribution={distribution} />}

--- a/src/components/Dashboard/BalanceModule.js
+++ b/src/components/Dashboard/BalanceModule.js
@@ -95,7 +95,7 @@ const BalanceModule = React.memo(
                       onClick: onRequestActivate,
                     },
                   ]}
-                  activity={inactiveBalance && inactiveBalance.latestMovement}
+                  activity={inactiveBalance?.latestMovement}
                   loading={loading}
                 />
               </Box>
@@ -114,7 +114,7 @@ const BalanceModule = React.memo(
                   actions={[
                     { label: 'Deactivate', onClick: onRequestDeactivate },
                   ]}
-                  activity={activeBalance && activeBalance.latestMovement}
+                  activity={activeBalance?.latestMovement}
                   distribution={lockedBalanceDistribution}
                   loading={loading}
                 />
@@ -139,7 +139,7 @@ const BalanceModule = React.memo(
               `}
             >
               <Balance
-                amount={walletBalance && walletBalance.amount}
+                amount={walletBalance?.amount}
                 label="My wallet"
                 mainIcon={walletIcon}
                 mainIconBackground={theme.accent.alpha(0.2)}
@@ -150,7 +150,7 @@ const BalanceModule = React.memo(
                     onClick: onRequestStakeActivate,
                   },
                 ]}
-                activity={walletBalance && walletBalance.latestMovement}
+                activity={walletBalance?.latestMovement}
                 loading={loading}
               />
             </div>

--- a/src/utils/anj-movement-utils.js
+++ b/src/utils/anj-movement-utils.js
@@ -262,9 +262,11 @@ export function convertMovement(acceptedMovements, movement) {
   const direction = getMovementDirection(acceptedMovements, movementType)
 
   return {
-    type: movementType,
     amount: movement.amount,
     direction,
+    isEffective: movement.isEffective,
+    isImmediate: movement.isImmediate,
+    type: movementType,
   }
 }
 


### PR DESCRIPTION
fixes #340 

Show a `Effective next term` message when the movement is immediate and not yet effective.

By immediate we mean that the movement had an immediate impact on the total balance.

E.g for activating tokens, the active balance is already increased, the increased amount is not yet effective in that is not going to be taken into account for drafting. 

**Preview**

Activating

**Not effective**
![Screen Shot 2020-06-02 at 9 56 07 PM](https://user-images.githubusercontent.com/22663232/83583927-0df44100-a51c-11ea-8af8-fd2e28f1c5e6.png)

**Effective**

![Screen Shot 2020-06-02 at 9 59 31 PM](https://user-images.githubusercontent.com/22663232/83584049-60cdf880-a51c-11ea-9019-0e5164e4a439.png)
