### PR TITLE
AccountModule: update "provider" copy to move towards wallets and accounts

### DIFF
--- a/src/components/Account/AccountModule.js
+++ b/src/components/Account/AccountModule.js
@@ -13,7 +13,7 @@ import ScreenProviders from './ScreenProviders'
 const SCREENS = [
   {
     id: 'providers',
-    title: 'Ethereum providers',
+    title: 'Use account from',
     height:
       4 * GU + // header
       (12 + 1.5) * GU * Math.ceil(getUseWalletProviders().length / 2) + // buttons
@@ -21,17 +21,17 @@ const SCREENS = [
   },
   {
     id: 'connecting',
-    title: 'Ethereum providers',
+    title: 'Use account from',
     height: 38 * GU,
   },
   {
     id: 'connected',
-    title: 'Active wallet',
+    title: 'Active account',
     height: 22 * GU,
   },
   {
     id: 'error',
-    title: 'Ethereum providers',
+    title: 'Connection error',
     height: 50 * GU,
   },
 ]

--- a/src/components/Account/ScreenProviders.js
+++ b/src/components/Account/ScreenProviders.js
@@ -45,7 +45,7 @@ function ScreenProviders({ onActivate }) {
         `}
       >
         <Link href="https://ethereum.org/wallets/" css="text-decoration: none">
-          What is an Ethereum provider?
+          Don’t have an Ethereum account?
         </Link>
       </div>
     </div>

--- a/src/components/Onboarding/Navigation.js
+++ b/src/components/Onboarding/Navigation.js
@@ -8,6 +8,7 @@ const buttonTransitionStyles = show => ({
   opacity: Number(show),
   transform: `translate3d(0, ${show ? 0 : 2}px, 0)`,
   config: springs.swift,
+  pointerEvents: show ? 'auto' : 'none',
 })
 
 const Navigation = ({ step, steps, onPrev, onNext }) => {

--- a/src/components/Onboarding/OnboardingModal.js
+++ b/src/components/Onboarding/OnboardingModal.js
@@ -34,7 +34,7 @@ const OnboardingModal = React.memo(function OnboardingModal({
         const compactMode = width < 500 || height < 400
         return (
           <Modal
-            onClose={onComplete}
+            closeButton={false}
             padding={0}
             width={Math.min(1055, width - 40)}
             visible={visible}

--- a/src/components/Onboarding/OnboardingModal.js
+++ b/src/components/Onboarding/OnboardingModal.js
@@ -34,6 +34,7 @@ const OnboardingModal = React.memo(function OnboardingModal({
         const compactMode = width < 500 || height < 400
         return (
           <Modal
+            onClose={onComplete}
             padding={0}
             width={Math.min(1055, width - 40)}
             visible={visible}


### PR DESCRIPTION
Closes #159, #349.

Also solves a bug in the Onboarding Modal: clicking the Close button (The X) doesn't close the modal.

Screenshots:
- Providers before:
![Screen Shot 2020-06-03 at 10 23 13 AM](https://user-images.githubusercontent.com/26014927/83648885-93abd700-a584-11ea-9135-27e2c732442e.png)
- Providers after (only two providers as I'm running it locally):
![Screen Shot 2020-06-03 at 10 22 38 AM](https://user-images.githubusercontent.com/26014927/83648913-9c041200-a584-11ea-8125-8c95e89d07a7.png)

- Connection error before:
![Screen Shot 2020-06-03 at 10 22 54 AM](https://user-images.githubusercontent.com/26014927/83649003-b76f1d00-a584-11ea-8bfc-c1633cd5cabe.png)
- Connection error after:
![Screen Shot 2020-06-03 at 10 22 47 AM](https://user-images.githubusercontent.com/26014927/83649024-bd64fe00-a584-11ea-81ce-911c73544f71.png)

- Connected before:
![Screen Shot 2020-06-03 at 10 23 52 AM](https://user-images.githubusercontent.com/26014927/83649111-d66daf00-a584-11ea-8e56-2bbb1b6ea58b.png)
- Connected after:
![Screen Shot 2020-06-03 at 10 23 29 AM](https://user-images.githubusercontent.com/26014927/83649079-cd7cdd80-a584-11ea-9b77-5e201f13ce35.png)

(Note that it kinda bugs me that we're using "account now" but we have "Disconnect wallet". It's accurate, but I think we could also change this to "Disconnect account")