### PR TITLE
Fix typo and clarify wording

### DIFF
--- a/src/components/Disputes/DisputeActions.js
+++ b/src/components/Disputes/DisputeActions.js
@@ -282,7 +282,7 @@ const useInfoAttributes = ({
 
     // Juror has voted and reveal period hasn't ended
     return {
-      title: 'Your vote was cast successfuly.',
+      title: 'Your vote was cast and revealed successfully.',
       paragraph: (
         <VoteInfo
           commitmentDate={jurorDraft.commitmentDate}

--- a/src/components/Disputes/DisputeActions.js
+++ b/src/components/Disputes/DisputeActions.js
@@ -282,7 +282,9 @@ const useInfoAttributes = ({
 
     // Juror has voted and reveal period hasn't ended
     return {
-      title: 'Your vote was cast and revealed successfully.',
+      title: `Your vote was cast ${
+        jurorDraft.outcome ? 'and revealed' : ''
+      } successfully.`,
       paragraph: (
         <VoteInfo
           commitmentDate={jurorDraft.commitmentDate}

--- a/src/components/Disputes/DisputeActions.js
+++ b/src/components/Disputes/DisputeActions.js
@@ -239,7 +239,7 @@ const useInfoAttributes = ({
       }
 
       // Juror has revealed
-      // Check if has voted in consensus with the majority for the last round
+      // Check if has voted in consensus with the plurality for the last round
       const hasVotedInConsensus =
         lastRound.vote && jurorDraft.outcome === lastRound.vote.winningOutcome
 
@@ -249,8 +249,8 @@ const useInfoAttributes = ({
       const settledPenalties = lastRound.settledPenalties
 
       const title = hasVotedInConsensus
-        ? 'You have voted in consensus with the majority'
-        : 'You have not voted in consensus with the majority'
+        ? 'You have voted in consensus with the plurality'
+        : 'You have not voted in consensus with the plurality'
       const background = hasVotedInConsensus
         ? positiveBackground
         : negativeBackground

--- a/src/components/Disputes/actions/DisputeVoting.js
+++ b/src/components/Disputes/actions/DisputeVoting.js
@@ -145,7 +145,7 @@ const RefuseToVoteHint = ({ compactMode, width }) => {
               description was incoherent.
             </p>
             <p>
-              Remember that you should vote the way that you think the majority
+              Remember that you should vote the way that you think the plurality
               of jurors will vote, since you will be penalized if your vote is
               in the minority.
             </p>

--- a/src/components/Onboarding/content.js
+++ b/src/components/Onboarding/content.js
@@ -104,8 +104,8 @@ highlights.rinkeby = [
       small: null,
       large: (
         <span>
-          When you vote in favor of the majority ruling, you will be rewarded
-          with arbitration fees. Just note that these rewards will be awarded in
+          When you vote in favor of the plurality ruling, you will be rewarded
+          with Dispute Fees. Just note that these rewards will be awarded in
           Rinkeby tokens for the purpose of this test version.
         </span>
       ),


### PR DESCRIPTION
- "successfuly" -> "successfully"
- Added "and revealed" so that jurors have an explicit acknowledgement that the reveal step worked properly
- Change "majority" to "plurality", because Aragon Court rulings are based on plurality rule, not majority rule.