### PR TITLE
Tasks: Use court clock

### DIFF
--- a/src/components/Tasks/TasksTable.js
+++ b/src/components/Tasks/TasksTable.js
@@ -9,7 +9,6 @@ import {
 } from '@aragon/ui'
 import IdentityBadge from '../IdentityBadge'
 import TasksFilters from './TasksFilters'
-import TaskStatus from './TaskStatus'
 import TaskDueDate from './TaskDueDate'
 
 import noResults from '../../assets/noResults.svg'
@@ -69,7 +68,7 @@ const TaskTable = React.memo(function TaskTable({
       fields={
         emptyFilterResults
           ? []
-          : ['Action', 'Dispute', 'Assigned to juror', 'Status', 'Due date']
+          : ['Action', 'Dispute', 'Assigned to juror', 'Due in']
       }
       entries={tasks}
       renderEntry={({ phase, disputeId, juror, dueDate }) => {
@@ -85,8 +84,6 @@ const TaskTable = React.memo(function TaskTable({
             Dispute #{disputeId}
           </Link>,
           <IdentityBadge entity={juror} />,
-
-          <TaskStatus dueDate={dueDate} />,
           <TaskDueDate dueDate={dueDate} />,
         ]
       }}

--- a/src/hooks/subscription-hooks.js
+++ b/src/hooks/subscription-hooks.js
@@ -23,7 +23,10 @@ import { bigNum } from '../lib/math-utils'
 import { dayjs } from '../utils/date-utils'
 import { groupMovements } from '../utils/anj-movement-utils'
 import { transformAppealDataAttributes } from '../utils/appeal-utils'
-import { transformDisputeDataAttributes } from '../utils/dispute-utils'
+import {
+  transformRoundDataAttributes,
+  transformDisputeDataAttributes,
+} from '../utils/dispute-utils'
 import { transformJurorDataAttributes } from '../utils/juror-draft-utils'
 import { transformClaimedFeesDataAttributes } from '../utils/subscription-utils'
 import {
@@ -330,7 +333,8 @@ export function useTasksSubscription() {
     variables: subscriptionVariables,
   })
 
-  const tasks = data?.adjudicationRounds || null
+  const tasks =
+    data?.adjudicationRounds.map(transformRoundDataAttributes) || null
 
   return { tasks, fetching: !data && !error, error }
 }

--- a/src/utils/dispute-utils.js
+++ b/src/utils/dispute-utils.js
@@ -8,6 +8,40 @@ import { getPrecedenceCampaignDisputesByCourt } from '../flagged-disputes/preced
 export const FINAL_ROUND_WEIGHT_PRECISION = bigNum(1000)
 export const PCT_BASE = bigNum(10000)
 
+export const transformRoundDataAttributes = round => {
+  const { vote, appeal } = round
+
+  return {
+    ...round,
+    createdAt: parseInt(round.createdAt, 10) * 1000,
+    draftTermId: parseInt(round.draftTermId, 10),
+    delayedTerms: parseInt(round.delayedTerms, 10),
+    number: parseInt(round.number),
+    jurors: round.jurors.map(juror => ({
+      ...juror,
+      commitmentDate: parseInt(juror.commitmentDate || 0, 10) * 1000,
+      revealDate: parseInt(juror.revealDate || 0, 10) * 1000,
+      weight: parseInt(juror.weight, 10),
+    })),
+    vote: vote
+      ? {
+          ...vote,
+          winningOutcome: getOutcomeNumber(vote.winningOutcome),
+        }
+      : null,
+    appeal: appeal
+      ? {
+          ...appeal,
+          appealedRuling: parseInt(appeal.appealedRuling, 10),
+          opposedRuling: parseInt(appeal.opposedRuling, 10),
+          createdAt: parseInt(appeal.createdAt) * 1000,
+          confirmedAt: parseInt(appeal.confirmedAt || 0) * 1000,
+        }
+      : null,
+    state: DisputesTypes.convertFromString(round.state),
+  }
+}
+
 export const transformDisputeDataAttributes = dispute => {
   const transformedDispute = {
     ...dispute,
@@ -18,39 +52,7 @@ export const transformDisputeDataAttributes = dispute => {
       DisputesTypes.Phase.Ruled
         ? DisputesTypes.Status.Closed
         : DisputesTypes.Status.Open,
-    rounds: dispute.rounds.map(round => {
-      const { vote, appeal } = round
-
-      return {
-        ...round,
-        createdAt: parseInt(round.createdAt, 10) * 1000,
-        draftTermId: parseInt(round.draftTermId, 10),
-        delayedTerms: parseInt(round.delayedTerms, 10),
-        number: parseInt(round.number),
-        jurors: round.jurors.map(juror => ({
-          ...juror,
-          commitmentDate: parseInt(juror.commitmentDate || 0, 10) * 1000,
-          revealDate: parseInt(juror.revealDate || 0, 10) * 1000,
-          weight: parseInt(juror.weight, 10),
-        })),
-        vote: vote
-          ? {
-              ...vote,
-              winningOutcome: getOutcomeNumber(vote.winningOutcome),
-            }
-          : null,
-        appeal: appeal
-          ? {
-              ...appeal,
-              appealedRuling: parseInt(appeal.appealedRuling, 10),
-              opposedRuling: parseInt(appeal.opposedRuling, 10),
-              createdAt: parseInt(appeal.createdAt) * 1000,
-              confirmedAt: parseInt(appeal.confirmedAt || 0) * 1000,
-            }
-          : null,
-        state: DisputesTypes.convertFromString(round.state),
-      }
-    }),
+    rounds: dispute.rounds.map(transformRoundDataAttributes),
   }
 
   // If the dispute is part of the precedence campaign we will flag it as such


### PR DESCRIPTION
closes #319 

- Removes redundant status from task table
- Uses court clock for updating tasks

While removing the redundant status, realized that we forgot to update the usage of the clock by tasks as well when implementing https://github.com/aragon/court-dashboard/pull/338 😅