### PR TITLE
Rewards module improvements

### DIFF
--- a/src/components/Dashboard/DashboardStateProvider.js
+++ b/src/components/Dashboard/DashboardStateProvider.js
@@ -3,7 +3,7 @@ import { useWallet } from '../../providers/Wallet'
 import {
   useAppealsByUserSubscription,
   useJurorBalancesSubscription,
-  useJurorDraftsNotRewardedSubscription,
+  useJurorDraftsRewardsSubscription,
 } from '../../hooks/subscription-hooks'
 
 const DashboardContext = React.createContext()
@@ -60,7 +60,7 @@ function WithSubscription({ Provider, connectedAccount, children }) {
     jurorDrafts,
     fetching: jurorDraftsFetching,
     error: jurorDraftsError,
-  } = useJurorDraftsNotRewardedSubscription(connectedAccount)
+  } = useJurorDraftsRewardsSubscription(connectedAccount)
 
   const fetching = balancesFetching || appealsFetching || jurorDraftsFetching
   const errors = [

--- a/src/hooks/useJurorSubscriptionFees.js
+++ b/src/hooks/useJurorSubscriptionFees.js
@@ -47,7 +47,10 @@ export default function useJurorSubscriptionFees() {
               jurorShare[1].gt(0) &&
               !hasJurorClaimed(claimedSubscriptionFees, periodId)
             ) {
-              jurorSubscriptionsFees.push({ periodId, amount: jurorShare[1] })
+              jurorSubscriptionsFees.push({
+                periodId,
+                amount: jurorShare[1],
+              })
             }
           }
         }

--- a/src/queries/appeals.js
+++ b/src/queries/appeals.js
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag'
 
 export const AppealsByMaker = gql`
-  subscription AppealsByMaker($maker: Bytes!, $settled: Boolean!) {
-    appeals(where: { maker: $maker, settled: $settled }) {
+  subscription AppealsByMaker($maker: Bytes!) {
+    appeals(where: { maker: $maker }) {
       id
       round {
         number
@@ -22,13 +22,15 @@ export const AppealsByMaker = gql`
       appealDeposit
       opposedRuling
       confirmAppealDeposit
+      settled
+      settledAt
     }
   }
 `
 
 export const AppealsByTaker = gql`
-  subscription AppealsByTaker($taker: Bytes!, $settled: Boolean!) {
-    appeals(where: { taker: $taker, settled: $settled }) {
+  subscription AppealsByTaker($taker: Bytes!) {
+    appeals(where: { taker: $taker }) {
       id
       round {
         number
@@ -48,6 +50,8 @@ export const AppealsByTaker = gql`
       taker
       opposedRuling
       confirmAppealDeposit
+      settled
+      settledAt
     }
   }
 `

--- a/src/queries/juror.js
+++ b/src/queries/juror.js
@@ -9,6 +9,21 @@ export const JurorFeesClaimed = gql`
   }
 `
 
+// Last juror fee withdrawal movement
+export const JurorLastFeeWithdrawal = gql`
+  subscription JurorLastFeeWithdrawal($owner: Bytes!) {
+    feeMovements(
+      where: { owner: $owner, type: "Withdraw" }
+      orderBy: createdAt
+      orderDirection: desc
+      first: 1
+    ) {
+      id
+      createdAt
+    }
+  }
+`
+
 export const ActiveJurors = gql`
   query ActiveJurors {
     jurors(first: 1000, where: { activeBalance_gt: 0 }) {

--- a/src/queries/jurorDrafts.js
+++ b/src/queries/jurorDrafts.js
@@ -1,12 +1,14 @@
 import gql from 'graphql-tag'
 
-// All juror drafts by `id` not yet rewarded
-export const JurorDraftsNotRewarded = gql`
-  subscription JurorDraftsNotRewarded($id: ID!) {
+// All juror drafts by juror with address `id`
+export const JurorDraftsRewards = gql`
+  subscription JurorDraftsRewards($id: ID!) {
     juror(id: $id) {
       id
-      drafts(where: { rewarded: false }) {
+      drafts {
         id
+        rewarded
+        rewardedAt
         weight
         outcome
         round {
@@ -21,18 +23,6 @@ export const JurorDraftsNotRewarded = gql`
             finalRuling
           }
         }
-      }
-    }
-  }
-`
-
-// First juror draft already rewarded
-export const JurorDraftsRewarded = gql`
-  query JurorDraftsRewarded($id: ID!) {
-    juror(id: $id) {
-      id
-      drafts(where: { rewarded: true }, first: 1) {
-        id
       }
     }
   }

--- a/src/utils/appeal-utils.js
+++ b/src/utils/appeal-utils.js
@@ -8,6 +8,7 @@ export function transformAppealDataAttributes(appeal) {
     appealDeposit,
     confirmAppealDeposit,
     round,
+    settledAt,
   } = appeal
 
   return {
@@ -28,6 +29,7 @@ export function transformAppealDataAttributes(appeal) {
     opposedRuling: parseInt(opposedRuling, 10),
     appealDeposit: bigNum(appealDeposit),
     confirmAppealDeposit: bigNum(confirmAppealDeposit),
+    settledAt: parseInt(settledAt || 0, 10) * 1000,
   }
 }
 

--- a/src/utils/juror-draft-utils.js
+++ b/src/utils/juror-draft-utils.js
@@ -29,10 +29,11 @@ export function isJurorCoherent(jurorDraft) {
 }
 
 export function transformJurorDataAttributes(jurorDraft) {
-  const { weight, round } = jurorDraft
+  const { rewardedAt, round, weight } = jurorDraft
 
   return {
     ...jurorDraft,
+    rewardedAt: parseInt(rewardedAt || 0, 10) * 1000,
     weight: bigNum(weight),
     round: {
       ...round,

--- a/src/utils/rewards-utils.js
+++ b/src/utils/rewards-utils.js
@@ -1,0 +1,22 @@
+import { bigNum } from '../lib/math-utils'
+
+export function getTotalFees(fees, key = 'amount') {
+  return Array.isArray(fees)
+    ? fees.reduce((acc, fee) => acc.add(fee[key]), bigNum(0))
+    : bigNum(0)
+}
+
+export function getTotalSettledFees(arbitrableFees, appealFees) {
+  return [arbitrableFees, appealFees]
+    .map(fees => getTotalFees(fees, 'settledAmount'))
+    .reduce((acc, amount) => acc.add(amount), bigNum(0))
+}
+
+export function filterSettledRounds(fees) {
+  return fees.map(({ rounds, ...fee }) => ({
+    ...fee,
+    rounds: rounds
+      .filter(({ settled }) => !settled)
+      .map(({ roundId }) => roundId),
+  }))
+}


### PR DESCRIPTION
closes #356 closes #235 

This PR requires https://github.com/aragon/court-subgraph/pull/62 and  https://github.com/aragon/court-subgraph/pull/65 to be deployed first.

In this PR we include already settled rewards to be taken into account for the Rewards module, with the condition that the time at which they were settled is after the time at which jurors did their last withdrawal from the treasury.

With this new implementation jurors can know exactly where do their rewards come from even after they were settled. 

Regarding [the notion item](https://www.notion.so/9e7e5cd565b44800a79b5640a5f094a8?v=d3b5e76c06634dafa4b7083edbaca881&p=2628acaeeaa344ed8ec3d7281b521e8e), we removed the Total divider, but included a new line separator as i felt the need to have some separation between the total and the partial reward amounts. 

**Preview**

![Screen Shot 2020-06-08 at 9 04 29 PM](https://user-images.githubusercontent.com/22663232/84092599-3f628600-a9ce-11ea-8e51-5f4adc921984.png)
