### PR TITLE
Identity badge: Remove connectedAccount prop

### DIFF
--- a/src/components/EmailNotifications/EmailNotificationsForm.js
+++ b/src/components/EmailNotifications/EmailNotificationsForm.js
@@ -106,11 +106,7 @@ function EmailNotificationsForm({
           {existingEmail ? (
             <>
               <span>Enter a new email address for your account</span>
-              <IdentityBadge
-                connectedAccount={account}
-                entity={account}
-                compact
-              />
+              <IdentityBadge entity={account} compact />
               <span>
                 . We will continue sending email notifications to the current
                 email address until you verify this new email address.
@@ -119,11 +115,7 @@ function EmailNotificationsForm({
           ) : (
             <>
               <span>Associate an email address to your account </span>
-              <IdentityBadge
-                connectedAccount={account}
-                entity={account}
-                compact
-              />
+              <IdentityBadge entity={account} compact />
               <span>
                 , so you can receive notifications for all Aragon Court events.
               </span>


### PR DESCRIPTION
We were passing the `connectedAccount` prop as a string to the `IdentityBadge` component when it should be a `Boolean`.

Ended up removing it as this prop is useful if we would like to have a `You` tag alongside the badge which i think it's not the case here?