### PR TITLE
chore: simplify sentry configuration to avoid requiring branch name

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -32,10 +32,6 @@ API key from [Portis](portis.io). Requires separate keys for testnet / mainnet.
 
 ## Flags
 
-### `REACT_APP_ENABLE_SENTRY`
-
-To enable error reporting to sentry
-
 ### `REACT_APP_SKIP_VOIDING`
 
 To disable flagging of voided disputes.

--- a/now.json
+++ b/now.json
@@ -7,8 +7,7 @@
     "env": {
       "REACT_APP_CHAIN_ID": "4",
       "REACT_APP_SUBGRAPH_NAME": "staging",
-      "REACT_APP_COURT_SERVER_NAME": "staging",
-      "REACT_APP_SENTRY_DSN": "@court-dashboard-sentry-dsn"
+      "REACT_APP_COURT_SERVER_NAME": "staging"
     }
   }
 }

--- a/scripts/build
+++ b/scripts/build
@@ -5,26 +5,6 @@ require('dotenv').config()
 const version = require('../package.json').version
 const execute = require('child_process').execSync
 
-let branch
-let enableSentry = '0'
-// Current branch
-if (process.env.NOW_GITHUB_COMMIT_REF) {
-  // ZEIT Now (no .git but an env var)
-  branch = process.env.NOW_GITHUB_COMMIT_REF
-} else if (process.env.GITHUB_REF) {
-  // Github Action
-  branch = process.env.GITHUB_REF
-} else {
-  // Other environments
-  branch = execute(`git symbolic-ref --short -q HEAD`)
-    .toString()
-    .trim()
-}
-
-if (branch === 'master') {
-  enableSentry = '1'
-}
-
 let build
 // Build number from the short hash
 if (process.env.NOW_GITHUB_COMMIT_SHA) {
@@ -37,9 +17,7 @@ if (process.env.NOW_GITHUB_COMMIT_SHA) {
     .trim()
 }
 
-console.log('Branch: ', branch)
 console.log('Build: ', build)
-console.log('Enable Sentry: ', enableSentry)
 console.log('Package version: ', version)
 console.log()
 
@@ -52,7 +30,7 @@ execute('npm run sync-assets', {
 console.log('Building app…')
 console.log()
 execute(
-  `cross-env REACT_APP_PACKAGE_VERSION=${version} REACT_APP_ENABLE_SENTRY=${enableSentry} REACT_APP_BUILD=${build} npx react-app-rewired build`,
+  `cross-env REACT_APP_PACKAGE_VERSION=${version} REACT_APP_BUILD=${build} npx react-app-rewired build`,
   {
     stdio: 'inherit',
   }

--- a/src/environment.js
+++ b/src/environment.js
@@ -15,9 +15,6 @@ const ENV_VARS = {
   DEFAULT_ETH_NODE() {
     return process.env.REACT_APP_DEFAULT_ETH_NODE || ''
   },
-  ENABLE_SENTRY() {
-    return process.env.REACT_APP_ENABLE_SENTRY === '1'
-  },
   FORTMATIC_API_KEY() {
     return process.env.REACT_APP_FORTMATIC_API_KEY || ''
   },

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -2,8 +2,7 @@ import { init as initSentry } from '@sentry/browser'
 import env from './environment'
 import { getNetworkType } from './lib/web3-utils'
 
-const SENTRY_DSN = env('SENTRY_DSN')
-export const sentryEnabled = Boolean(SENTRY_DSN && env('ENABLE_SENTRY'))
+export const sentryEnabled = Boolean(env('SENTRY_DSN'))
 
 export default function initializeSentry() {
   if (sentryEnabled) {


### PR DESCRIPTION
We did this simplification over at the network-dashboard as well.

We don't need to detect the branch any more, since our default `now` target is now staging and we can just disable the sentry dsn there.