### PR TITLE
Routing: use hash router

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { BrowserRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router-dom'
 import { Main, ToastHub } from '@aragon/ui'
 import theme from './theme-court'
 import AppLoader from './components/AppLoader'
@@ -18,7 +18,7 @@ import { WalletProvider } from './providers/Wallet'
 function App() {
   return (
     <WalletProvider>
-      <BrowserRouter>
+      <HashRouter>
         <ActivityProvider>
           <Main
             assetsUrl="/aragon-ui/"
@@ -47,7 +47,7 @@ function App() {
             </GlobalErrorHandler>
           </Main>
         </ActivityProvider>
-      </BrowserRouter>
+      </HashRouter>
     </WalletProvider>
   )
 }


### PR DESCRIPTION
It turns out it's still impossible to have a consistent routing experience on IPFS (across the general case of all gateways) without using a hash router.

We will be transitioning this frontend to be hosted by Fleek, which allows us to directly leverage IPFS and IPNS.