### PR TITLE
Fix BigNumber usage

### DIFF
--- a/src/lib/math-utils.js
+++ b/src/lib/math-utils.js
@@ -128,7 +128,7 @@ export function getPercentageBN(value, totalValue) {
 }
 
 export function generateRandomNumber() {
-  const code = EthersUtils.bigNumberify(EthersUtils.randomBytes(32))
+  const code = BigNumber.from(EthersUtils.randomBytes(32))
   return code.toHexString().slice(2)
 }
 


### PR DESCRIPTION
fixes #390  

When upgrading ethers to v5, forgot to update the `BigNumber` constructor