### PR TITLE
Dispute: disable executions

### DIFF
--- a/src/components/Disputes/actions/DisputeExecuteRuling.js
+++ b/src/components/Disputes/actions/DisputeExecuteRuling.js
@@ -1,9 +1,11 @@
 import React, { useCallback } from 'react'
 import { Button, GU, Info } from '@aragon/ui'
-import { useWallet } from '../../../providers/Wallet'
+// import { useWallet } from '../../../providers/Wallet'
 
+// TODO(2020-09-07): we are disallowing disputes related to the AN Cash DAO from being executed for
+// now and will re-enable it at a future time
 function DisputeExecuteRuling({ disputeId, onExecuteRuling }) {
-  const wallet = useWallet()
+  // const wallet = useWallet()
 
   const handleSubmit = useCallback(
     event => {
@@ -23,12 +25,13 @@ function DisputeExecuteRuling({ disputeId, onExecuteRuling }) {
           margin-bottom: ${1.5 * GU}px;
         `}
       >
-        <Button type="submit" mode="strong" wide disabled={!wallet.account}>
+        <Button type="submit" mode="strong" wide disabled>
           Execute ruling
         </Button>
       </div>
       <Info>
-        <strong>Anyone</strong> can now trigger this action.
+        This action is part of the precedence campaign and will be executed when
+        all disputes have finished.
       </Info>
     </form>
   )

--- a/src/hooks/useCourtContracts.js
+++ b/src/hooks/useCourtContracts.js
@@ -186,10 +186,12 @@ export function useDisputeActions() {
   )
   const votingContract = useCourtContract(CourtModuleType.Voting, votingAbi)
 
+  /*
   const aragonCourtContract = useCourtContract(
     CourtModuleType.AragonCourt,
     aragonCourtAbi
   )
+  */
 
   const feeTokenContract = useFeeTokenContract()
 
@@ -386,8 +388,11 @@ export function useDisputeActions() {
     [appeal, approveFeeDeposit, confirmAppeal, processRequests]
   )
 
+  // TODO(2020-09-07): we are disallowing disputes related to the AN Cash DAO from being executed
+  // for now and will re-enable it at a future time
   const executeRuling = useCallback(
     disputeId => {
+      /*
       return processRequests([
         {
           action: () =>
@@ -398,8 +403,11 @@ export function useDisputeActions() {
           type: actions.EXECUTE_RULING,
         },
       ])
+      */
     },
-    [aragonCourtContract, processRequests]
+    [
+      /* aragonCourtContract, processRequests */
+    ]
   )
 
   return {

--- a/src/types/dispute-status-types.js
+++ b/src/types/dispute-status-types.js
@@ -40,7 +40,7 @@ const stringMapping = {
   [Phase.ClaimRewards]: 'Claim rewards',
   [Phase.Invalid]: 'Invalid',
   [Phase.Ended]: 'Ended',
-  [Phase.ExecuteRuling]: 'Execute Ruling',
+  [Phase.ExecuteRuling]: 'Waiting',
   [Phase.Created]: 'Dispute created',
 }
 


### PR DESCRIPTION
Quick frontend update to disable the current set of precedence campaign disputes from being executed, until all of them have finalized.