### PR TITLE
Dispute timeline: Prevent accordion from auto-collapsing

### DIFF
--- a/src/components/Disputes/DisputeTimeline.js
+++ b/src/components/Disputes/DisputeTimeline.js
@@ -7,9 +7,6 @@ import DisputeRoundPill from './DisputeRoundPill'
 import Step from '../Step'
 import Stepper from '../Stepper'
 
-import { useCourtClock } from '../../providers/CourtClock'
-import { useCourtConfig } from '../../providers/CourtConfig'
-
 import {
   IconFlag,
   IconFolder,
@@ -26,22 +23,15 @@ import {
   getPhaseStringForStatus,
 } from '../../types/dispute-status-types'
 import { dateFormat } from '../../utils/date-utils'
-import { getDisputeTimeLine } from '../../utils/dispute-utils'
+import useDisputeTimeline from '../../hooks/useDisputeTimeline'
 
-const DisputeTimeline = React.memo(function DisputeTimeline({ dispute }) {
+const Timeline = React.memo(function Timeline({ timeline }) {
   const theme = useTheme()
-  const courtConfig = useCourtConfig()
-  const { currentTermId } = useCourtClock()
-  const disputeTimeLine = getDisputeTimeLine(
-    dispute,
-    courtConfig,
-    currentTermId
-  )
 
   return (
     <div>
       <Stepper lineColor={theme.accent.alpha(0.3)} lineTop={12}>
-        {disputeTimeLine.map((item, index) => {
+        {timeline.map((item, index) => {
           if (!Array.isArray(item)) {
             return <ItemStep key={index} item={item} index={index} />
           }
@@ -302,4 +292,8 @@ const StyledAccordion = styled.div`
   }
 `
 
-export default DisputeTimeline
+export default function DisputeTimeline({ dispute }) {
+  const disputeTimeLine = useDisputeTimeline(dispute)
+
+  return <Timeline timeline={disputeTimeLine} />
+}

--- a/src/hooks/useDisputeTimeline.js
+++ b/src/hooks/useDisputeTimeline.js
@@ -1,0 +1,94 @@
+import { useMemo } from 'react'
+import { Phase as DisputePhase } from '../types/dispute-status-types'
+import { getTermEndTime } from '../utils/court-utils'
+import {
+  getEvidenceSubmissionEndTerm,
+  getPhaseAndTransition,
+  getRoundPhasesAndTime,
+} from '../utils/dispute-utils'
+import { useCourtConfig } from '../providers/CourtConfig'
+import { useCourtClock } from '../providers/CourtClock'
+
+/**
+ * Construct dispute timeline for the given dispute
+ * @param {Object} dispute The dispute to get the timeline from
+ * @param {Object} courtConfig The court configuration
+ * @param {Number} currentTerm The court current term
+ * @returns {Array} The timeline of the given dispute
+ */
+export default function useDisputeTimeline(dispute) {
+  const courtConfig = useCourtConfig()
+  const { currentTermId } = useCourtClock()
+  const { createdAt } = dispute
+
+  const currentPhase = getPhaseAndTransition(
+    dispute,
+    currentTermId,
+    courtConfig
+  )
+
+  const evidenceSubmissionEndTerm = getEvidenceSubmissionEndTerm(
+    dispute,
+    courtConfig
+  )
+  const evidenceSubmissionEndTime = getTermEndTime(
+    evidenceSubmissionEndTerm,
+    courtConfig
+  )
+
+  return useMemo(
+    () => {
+      const timeLine = [
+        {
+          phase: DisputePhase.Evidence,
+          endTime: evidenceSubmissionEndTime,
+          active: currentPhase.phase === DisputePhase.Evidence,
+          roundId: 0,
+        },
+        {
+          phase: DisputePhase.Created, // create Symbol
+          endTime: createdAt,
+        },
+      ]
+
+      const rounds = []
+      dispute.rounds.forEach(round => {
+        const roundPhases = getRoundPhasesAndTime(
+          round,
+          currentPhase,
+          currentTermId,
+          courtConfig
+        )
+        rounds.unshift([...roundPhases].reverse())
+      })
+
+      if (rounds.length === 0) {
+        return timeLine
+      }
+
+      timeLine.unshift(rounds)
+
+      if (
+        currentPhase.phase === DisputePhase.ExecuteRuling ||
+        currentPhase.phase === DisputePhase.ClaimRewards
+      ) {
+        timeLine.unshift({
+          phase: DisputePhase.ExecuteRuling,
+          active: DisputePhase.ExecuteRuling === currentPhase.phase,
+          roundId: currentPhase.roundId,
+        })
+      }
+
+      if (currentPhase.phase === DisputePhase.ClaimRewards) {
+        timeLine.unshift({
+          phase: DisputePhase.ClaimRewards,
+          active: currentPhase.phase === DisputePhase.ClaimRewards,
+          roundId: currentPhase.roundId,
+        })
+      }
+
+      return timeLine
+    },
+    [createdAt, currentPhase.phase, evidenceSubmissionEndTime] // eslint-disable-line react-hooks/exhaustive-deps
+  )
+}

--- a/src/hooks/useDisputeTimeline.js
+++ b/src/hooks/useDisputeTimeline.js
@@ -89,6 +89,10 @@ export default function useDisputeTimeline(dispute) {
 
       return timeLine
     },
+
+    // We are leaving out courtConfig and dispute.rounds as dependencies to prevent  the timeline  from being recomputed on every poll.
+    // The current phase dependency is sufficient for recomputing it.
+    // If there's a new round, means the phase has changed
     [createdAt, currentPhase.phase, evidenceSubmissionEndTime] // eslint-disable-line react-hooks/exhaustive-deps
   )
 }

--- a/src/hooks/useDisputeTimeline.js
+++ b/src/hooks/useDisputeTimeline.js
@@ -90,7 +90,7 @@ export default function useDisputeTimeline(dispute) {
       return timeLine
     },
 
-    // We are leaving out courtConfig and dispute.rounds as dependencies to prevent  the timeline  from being recomputed on every poll.
+    // We are leaving out courtConfig and dispute.rounds as dependencies to prevent the timeline from being recomputed on every poll.
     // The current phase dependency is sufficient for recomputing it.
     // If there's a new round, means the phase has changed
     [createdAt, currentPhase.phase, evidenceSubmissionEndTime] // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/utils/dispute-utils.js
+++ b/src/utils/dispute-utils.js
@@ -111,83 +111,6 @@ function overrideVoidedDispute(dispute, voidedDispute) {
 }
 
 /**
- * Construct dispute timeline for the given dispute
- * @param {Object} dispute The dispute to get the timeline from
- * @param {Object} courtConfig The court configuration
- * @param {Number} currentTerm The court current term
- * @returns {Array} The timeline of the given dispute
- */
-export function getDisputeTimeLine(dispute, courtConfig, currentTerm) {
-  const { createdAt } = dispute
-
-  const currentPhaseAndTime = getPhaseAndTransition(
-    dispute,
-    currentTerm,
-    courtConfig
-  )
-
-  const evidenceSubmissionEndTerm = getEvidenceSubmissionEndTerm(
-    dispute,
-    courtConfig
-  )
-  const evidenceSubmissionEndTime = getTermEndTime(
-    evidenceSubmissionEndTerm,
-    courtConfig
-  )
-
-  const timeLine = [
-    {
-      phase: DisputesTypes.Phase.Evidence,
-      endTime: evidenceSubmissionEndTime,
-      active: currentPhaseAndTime.phase === DisputesTypes.Phase.Evidence,
-      roundId: 0,
-    },
-    {
-      phase: DisputesTypes.Phase.Created, // create Symbol
-      endTime: createdAt,
-    },
-  ]
-
-  const rounds = []
-  dispute.rounds.forEach(round => {
-    const roundPhases = getRoundPhasesAndTime(
-      round,
-      currentPhaseAndTime,
-      currentTerm,
-      courtConfig
-    )
-    rounds.unshift([...roundPhases].reverse())
-  })
-
-  if (rounds.length === 0) {
-    return timeLine
-  }
-
-  timeLine.unshift(rounds)
-
-  if (
-    currentPhaseAndTime.phase === DisputesTypes.Phase.ExecuteRuling ||
-    currentPhaseAndTime.phase === DisputesTypes.Phase.ClaimRewards
-  ) {
-    timeLine.unshift({
-      phase: DisputesTypes.Phase.ExecuteRuling,
-      active: DisputesTypes.Phase.ExecuteRuling === currentPhaseAndTime.phase,
-      roundId: currentPhaseAndTime.roundId,
-    })
-  }
-
-  if (currentPhaseAndTime.phase === DisputesTypes.Phase.ClaimRewards) {
-    timeLine.unshift({
-      phase: DisputesTypes.Phase.ClaimRewards,
-      active: currentPhaseAndTime.phase === DisputesTypes.Phase.ClaimRewards,
-      roundId: currentPhaseAndTime.roundId,
-    })
-  }
-
-  return timeLine
-}
-
-/**
  * @param {Object} dispute The dispute to query the current phase and next transition of
  * @param {Number} currentTerm The court current term
  * @param {Object} courtConfig The court configuration
@@ -394,7 +317,12 @@ export function getAdjudicationPhase(dispute, round, termId, courtConfig) {
  * @param {Object} courtConfig The court configuration
  * @returns {Array} Array of all `round` phases.
  */
-function getRoundPhasesAndTime(round, currentPhase, currentTerm, courtConfig) {
+export function getRoundPhasesAndTime(
+  round,
+  currentPhase,
+  currentTerm,
+  courtConfig
+) {
   const {
     commitTerms,
     revealTerms,
@@ -540,7 +468,7 @@ function getRoundPhasesAndTime(round, currentPhase, currentTerm, courtConfig) {
  * @param {Object} courtConfig The court configuration
  * @returns {Number} The end time of the evidence submission phase in ms
  */
-function getEvidenceSubmissionEndTerm(dispute, courtConfig) {
+export function getEvidenceSubmissionEndTerm(dispute, courtConfig) {
   const firstRound = dispute.rounds[0]
 
   // If the evidence period is closed before the full `evidenceTerms` period,


### PR DESCRIPTION
fixes #404 

We had to convert `getDisputeTimeline` to a hook `useDisputeTimeline`.