### PR TITLE
fix: changes mainnet subgraph to decentralized solution

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -40,6 +40,9 @@ const ENV_VARS = {
   SUBGRAPH_NAME() {
     return process.env.REACT_APP_SUBGRAPH_NAME
   },
+  SUBGRAPH_API_KEY() {
+    return process.env.REACT_APP_SUBGRAPH_API_KEY
+  }
 }
 
 export default function env(name) {

--- a/src/networks.js
+++ b/src/networks.js
@@ -16,7 +16,7 @@ export const networkConfigs = {
     nodes: {
       defaultEth: 'https://mainnet.eth.aragon.network/',
       subgraph:
-        'https://api.studio.thegraph.com/query/82696/aragon-court/version/latest',
+        `https://gateway-arbitrum.network.thegraph.com/api/${environment('SUBGRAPH_API_KEY')}/subgraphs/id/5vVqwtdSwUFE4UL5zCR1GShhEMMinM1GoNB8dendRUdd`,
     },
   },
   rinkeby: {


### PR DESCRIPTION
The previous change wasn't complete and didn't work.
This pull corrects the previous mistake and adds a new env variable `REACT_APP_SUBGRAPH_API_KEY` to define the API key used for the decentralized subgraph solution during build time.